### PR TITLE
Add ticket attachments, watchers, and audit logging

### DIFF
--- a/api/cmd/api/go.mod
+++ b/api/cmd/api/go.mod
@@ -10,4 +10,6 @@ require (
     github.com/joho/godotenv v1.5.1
     github.com/golang-jwt/jwt/v5 v5.2.0
     github.com/MicahParks/keyfunc v1.13.0
+    github.com/minio/minio-go/v7 v7.0.68
+    github.com/google/uuid v1.6.0
 )

--- a/api/cmd/api/migrations/0003_watchers.sql
+++ b/api/cmd/api/migrations/0003_watchers.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+create table if not exists ticket_watchers (
+    ticket_id uuid not null references tickets(id) on delete cascade,
+    user_id uuid not null references users(id) on delete cascade,
+    added_at timestamptz not null default now(),
+    primary key (ticket_id, user_id)
+);
+
+-- +goose Down
+drop table if exists ticket_watchers;


### PR DESCRIPTION
## Summary
- support MinIO configuration and ticket attachment upload, list, and deletion
- track ticket status history and audit events for ticket lifecycle changes
- add ticket watcher management endpoints and schema

## Testing
- `go mod tidy` *(fails: Forbidden)*
- `go build ./...` *(fails: missing go.sum entries due to offline module fetching)*
- `go test ./...` *(fails: missing go.sum entries due to offline module fetching)*

------
https://chatgpt.com/codex/tasks/task_e_68b41a80fab483229ba9d3abeb5c1de8