### PR TITLE
Add JWKS-backed auth, test bypass, interfaces, and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ A minimal FootPrints-style ticketing system scaffold in Go, with PostgreSQL migr
 - Auth uses OIDC JWTs with role checks (agents required for ticket updates).
 - Worker service is scaffolded but not wired to a queue yet.
 - This is a starter kit—intended to be iterated on.
+
+### Testing
+- Unit tests can bypass JWT validation by setting `TEST_BYPASS_AUTH=true`. This injects a synthetic user with the `agent` role so auth-protected routes can be exercised without a JWKS.
+- Handlers depend on a database interface and an object storage interface, enabling mocks/fakes in tests without external services.

--- a/api/cmd/api/auth_jwks_test.go
+++ b/api/cmd/api/auth_jwks_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+    "context"
+    "crypto/rand"
+    "crypto/rsa"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+
+    "github.com/golang-jwt/jwt/v5"
+    "github.com/jackc/pgx/v5"
+    "github.com/jackc/pgx/v5/pgconn"
+    "github.com/lestrrat-go/jwx/v2/jwk"
+)
+
+// fakeRow implements pgx.Row
+type fakeRow struct{
+    err error
+    scan func(dest ...any) error
+}
+func (r *fakeRow) Scan(dest ...any) error {
+    if r.err != nil { return r.err }
+    if r.scan != nil { return r.scan(dest...) }
+    return nil
+}
+
+// fakeRows implements pgx.Rows with minimal behavior used in code
+type fakeRows struct{}
+func (r *fakeRows) Close() {}
+func (r *fakeRows) Err() error { return nil }
+func (r *fakeRows) CommandTag() pgconn.CommandTag { return pgconn.CommandTag{} }
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeRows) Next() bool { return false }
+func (r *fakeRows) Scan(dest ...any) error { return nil }
+func (r *fakeRows) Values() ([]any, error) { return nil, nil }
+func (r *fakeRows) RawValues() [][]byte { return nil }
+func (r *fakeRows) Conn() *pgx.Conn { return nil }
+
+// fakeDB satisfies the DB interface and simulates user lookup/insert and empty roles
+type fakeDB struct{}
+func (db *fakeDB) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+    // roles query returns empty set
+    return &fakeRows{}, nil
+}
+func (db *fakeDB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+    s := strings.ToLower(sql)
+    if strings.Contains(s, "from users where external_id") {
+        // simulate no existing user
+        return &fakeRow{err: pgx.ErrNoRows}
+    }
+    if strings.HasPrefix(strings.TrimSpace(s), "insert into users") {
+        // return a generated id
+        return &fakeRow{scan: func(dest ...any) error {
+            if len(dest) > 0 {
+                if p, ok := dest[0].(*string); ok { *p = "00000000-0000-0000-0000-000000000001" }
+            }
+            return nil
+        }}
+    }
+    return &fakeRow{}
+}
+func (db *fakeDB) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
+    return pgconn.CommandTag{}, nil
+}
+
+func TestAuth_WithJWKS_ValidToken(t *testing.T) {
+    // generate RSA keypair
+    priv, err := rsa.GenerateKey(rand.Reader, 2048)
+    if err != nil { t.Fatalf("rsa generate: %v", err) }
+
+    // build JWK Set with public key
+    pubJWK, err := jwk.FromRaw(&priv.PublicKey)
+    if err != nil { t.Fatalf("jwk from raw: %v", err) }
+    _ = pubJWK.Set("kid", "test-key")
+    _ = pubJWK.Set("alg", "RS256")
+    set := jwk.NewSet()
+    set.AddKey(pubJWK)
+
+    // JWKS server
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        _ = json.NewEncoder(w).Encode(set)
+    }))
+    defer ts.Close()
+
+    // keyfunc using the JWKS URL (single fetch)
+    keyset, err := jwk.Fetch(context.Background(), ts.URL)
+    if err != nil { t.Fatalf("fetch jwks: %v", err) }
+    keyf := func(tk *jwt.Token) (any, error) {
+        kid, _ := tk.Header["kid"].(string)
+        if kid != "" {
+            if key, ok := keyset.LookupKeyID(kid); ok {
+                var pub any
+                if err := key.Raw(&pub); err != nil { return nil, err }
+                return pub, nil
+            }
+        }
+        it := keyset.Iterate(context.Background())
+        if it.Next(context.Background()) {
+            pair := it.Pair()
+            if key, ok := pair.Value.(jwk.Key); ok {
+                var pub any
+                if err := key.Raw(&pub); err != nil { return nil, err }
+                return pub, nil
+            }
+        }
+        return nil, jwt.ErrTokenSignatureInvalid
+    }
+
+    // sign a JWT
+    claims := jwt.MapClaims{
+        "iss": "https://issuer.example",
+        "sub": "user-123",
+        "email": "user@example.com",
+        "name": "User Name",
+    }
+    token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+    token.Header["kid"] = "test-key"
+    signed, err := token.SignedString(priv)
+    if err != nil { t.Fatalf("sign token: %v", err) }
+
+    cfg := Config{Env: "test", OIDCIssuer: "https://issuer.example"}
+    app := NewApp(cfg, &fakeDB{}, keyf, nil)
+
+    rr := httptest.NewRecorder()
+    req := httptest.NewRequest(http.MethodGet, "/me", nil)
+    req.Header.Set("Authorization", "Bearer "+signed)
+    app.r.ServeHTTP(rr, req)
+
+    if rr.Code != http.StatusOK {
+        t.Fatalf("expected 200, got %d. body=%s", rr.Code, rr.Body.String())
+    }
+}

--- a/api/cmd/api/go.mod
+++ b/api/cmd/api/go.mod
@@ -1,15 +1,69 @@
 module github.com/you/helpdesk/api
 
-go 1.22.0
+go 1.23.0
+
+toolchain go1.24.6
 
 require (
-    github.com/gin-gonic/gin v1.10.0
-    github.com/jackc/pgx/v5 v5.6.0
-    github.com/pressly/goose/v3 v3.20.0
-    github.com/rs/zerolog v1.32.0
-    github.com/joho/godotenv v1.5.1
-    github.com/golang-jwt/jwt/v5 v5.2.0
-    github.com/MicahParks/keyfunc v1.13.0
-    github.com/minio/minio-go/v7 v7.0.68
-    github.com/google/uuid v1.6.0
+	github.com/gin-gonic/gin v1.10.0
+	github.com/golang-jwt/jwt/v5 v5.2.0
+	github.com/google/uuid v1.6.0
+	github.com/jackc/pgx/v5 v5.6.0
+	github.com/joho/godotenv v1.5.1
+	github.com/lestrrat-go/jwx/v2 v2.1.6
+	github.com/minio/minio-go/v7 v7.0.68
+	github.com/pressly/goose/v3 v3.20.0
+	github.com/rs/zerolog v1.32.0
+)
+
+require (
+	github.com/bytedance/sonic v1.11.6 // indirect
+	github.com/bytedance/sonic/loader v0.1.1 // indirect
+	github.com/cloudwego/base64x v0.1.4 // indirect
+	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.20.0 // indirect
+	github.com/goccy/go-json v0.10.3 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.17.6 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/lestrrat-go/blackmagic v1.0.3 // indirect
+	github.com/lestrrat-go/httpcc v1.0.1 // indirect
+	github.com/lestrrat-go/httprc v1.0.6 // indirect
+	github.com/lestrrat-go/iter v1.0.2 // indirect
+	github.com/lestrrat-go/option v1.0.1 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mfridman/interpolate v0.0.2 // indirect
+	github.com/minio/md5-simd v1.1.2 // indirect
+	github.com/minio/sha256-simd v1.0.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/rs/xid v1.5.0 // indirect
+	github.com/segmentio/asm v1.2.0 // indirect
+	github.com/sethvargo/go-retry v0.2.4 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/ugorji/go/codec v1.2.12 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/arch v0.8.0 // indirect
+	golang.org/x/crypto v0.32.0 // indirect
+	golang.org/x/net v0.25.0 // indirect
+	golang.org/x/sync v0.10.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
+	google.golang.org/protobuf v1.34.1 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/api/cmd/api/main_test.go
+++ b/api/cmd/api/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+func TestHealthz(t *testing.T) {
+    cfg := Config{Env: "test"}
+    app := NewApp(cfg, nil, nil, nil)
+
+    rr := httptest.NewRecorder()
+    req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+    app.r.ServeHTTP(rr, req)
+
+    if rr.Code != http.StatusOK {
+        t.Fatalf("expected 200, got %d", rr.Code)
+    }
+    var body map[string]any
+    if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+        t.Fatalf("invalid json: %v", err)
+    }
+    if ok, _ := body["ok"].(bool); !ok {
+        t.Fatalf("expected ok=true in body, got: %v", body)
+    }
+}
+
+func TestMe_BypassAuth(t *testing.T) {
+    cfg := Config{Env: "test", TestBypassAuth: true}
+    app := NewApp(cfg, nil, nil, nil)
+
+    rr := httptest.NewRecorder()
+    req := httptest.NewRequest(http.MethodGet, "/me", nil)
+    app.r.ServeHTTP(rr, req)
+
+    if rr.Code != http.StatusOK {
+        t.Fatalf("expected 200, got %d", rr.Code)
+    }
+    var user AuthUser
+    if err := json.Unmarshal(rr.Body.Bytes(), &user); err != nil {
+        t.Fatalf("invalid json: %v", err)
+    }
+    if user.ID == "" || user.Email == "" {
+        t.Fatalf("expected synthetic user, got: %+v", user)
+    }
+    // Should include agent role by default for bypass
+    found := false
+    for _, r := range user.Roles {
+        if r == "agent" {
+            found = true
+            break
+        }
+    }
+    if !found {
+        t.Fatalf("expected role 'agent' in %+v", user.Roles)
+    }
+}
+
+func TestMe_NoBypass_NoJWKS(t *testing.T) {
+    cfg := Config{Env: "test", TestBypassAuth: false}
+    app := NewApp(cfg, nil, nil, nil)
+
+    rr := httptest.NewRecorder()
+    req := httptest.NewRequest(http.MethodGet, "/me", nil)
+    app.r.ServeHTTP(rr, req)
+
+    if rr.Code != http.StatusInternalServerError {
+        t.Fatalf("expected 500 due to missing JWKS, got %d", rr.Code)
+    }
+}
+


### PR DESCRIPTION
This PR improves testability and reinstates JWT verification with JWKS.

Key changes
- JWKS auth: Use `lestrrat-go/jwx/v2/jwk` to fetch and refresh JWKS; resolve by `kid` with safe fallback.
- Test bypass: Add `TEST_BYPASS_AUTH=true` to inject a synthetic user (handy for unit tests).
- DI-friendly app: `NewApp(cfg, db, keyfunc, store)` constructor; inject `jwt.Keyfunc` and small interfaces.
- Minimal interfaces: `DB` and `ObjectStore` for mocking DB and MinIO in tests.
- Migrations: Run goose via `database/sql` + pgx stdlib for compatibility.
- Tests: Health, auth bypass path, and an end-to-end JWKS JWT validation test using an in-memory JWKS server.
- Docs: README notes on testing and auth bypass.

Notes
- Default behavior unchanged for prod unless `OIDC_JWKS_URL` is set.
- Bypass is only for tests/dev via env var.

Test status
- `go test -v ./api/cmd/api` passes locally.

