### PR TITLE
Add IMAP polling worker job

### DIFF
--- a/worker/cmd/worker/go.mod
+++ b/worker/cmd/worker/go.mod
@@ -1,10 +1,15 @@
 module github.com/you/helpdesk/worker
 
-go 1.23
+go 1.23.0
+
+toolchain go1.24.3
 
 require (
+	github.com/emersion/go-imap v1.2.1
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/joho/godotenv v1.5.1
+	github.com/minio/minio-go/v7 v7.0.95
 	github.com/redis/go-redis/v9 v9.5.1
 	github.com/rs/zerolog v1.32.0
 )
@@ -12,13 +17,25 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21 // indirect
+	github.com/go-ini/ini v1.67.0 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.11 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
-	golang.org/x/crypto v0.17.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
+	github.com/minio/crc64nvme v1.0.2 // indirect
+	github.com/minio/md5-simd v1.1.2 // indirect
+	github.com/philhofer/fwd v1.2.0 // indirect
+	github.com/rs/xid v1.6.0 // indirect
+	github.com/tinylib/msgp v1.3.0 // indirect
+	golang.org/x/crypto v0.39.0 // indirect
+	golang.org/x/net v0.41.0 // indirect
+	golang.org/x/sync v0.15.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/text v0.26.0 // indirect
 )

--- a/worker/cmd/worker/imap.go
+++ b/worker/cmd/worker/imap.go
@@ -20,7 +20,11 @@ import (
 
 // pollIMAP connects to an IMAP inbox, retrieves new messages and stores them.
 func pollIMAP(ctx context.Context, c Config, db *pgxpool.Pool, mc *minio.Client) error {
-	addr := fmt.Sprintf("%s:993", c.IMAPHost)
+	port := c.IMAPPort
+	if port == 0 {
+		port = 993
+	}
+	addr := fmt.Sprintf("%s:%d", c.IMAPHost, port)
 	cli, err := imapclient.DialTLS(addr, nil)
 	if err != nil {
 		return err

--- a/worker/cmd/worker/imap.go
+++ b/worker/cmd/worker/imap.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/mail"
+	"regexp"
+	"strconv"
+
+	"github.com/emersion/go-imap"
+	imapclient "github.com/emersion/go-imap/client"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/minio/minio-go/v7"
+	"github.com/rs/zerolog/log"
+)
+
+// pollIMAP connects to an IMAP inbox, retrieves new messages and stores them.
+func pollIMAP(ctx context.Context, c Config, db *pgxpool.Pool, mc *minio.Client) error {
+	addr := fmt.Sprintf("%s:993", c.IMAPHost)
+	cli, err := imapclient.DialTLS(addr, nil)
+	if err != nil {
+		return err
+	}
+	defer cli.Logout()
+
+	if err := cli.Login(c.IMAPUser, c.IMAPPass); err != nil {
+		return err
+	}
+
+	mbox, err := cli.Select(c.IMAPFolder, false)
+	if err != nil {
+		return err
+	}
+	if mbox.Messages == 0 {
+		return nil
+	}
+
+	criteria := imap.NewSearchCriteria()
+	criteria.WithoutFlags = []string{imap.SeenFlag}
+	uids, err := cli.Search(criteria)
+	if err != nil || len(uids) == 0 {
+		return err
+	}
+
+	seqset := new(imap.SeqSet)
+	seqset.AddNum(uids...)
+	section := &imap.BodySectionName{}
+	messages := make(chan *imap.Message, 10)
+	done := make(chan error, 1)
+	go func() {
+		done <- cli.Fetch(seqset, []imap.FetchItem{imap.FetchEnvelope, section.FetchItem()}, messages)
+	}()
+
+	for msg := range messages {
+		if msg == nil {
+			continue
+		}
+		r := msg.GetBody(section)
+		if r == nil {
+			continue
+		}
+		raw, err := io.ReadAll(r)
+		if err != nil {
+			log.Error().Err(err).Msg("read body")
+			continue
+		}
+
+		key := fmt.Sprintf("email/%s.eml", uuid.NewString())
+		if mc != nil && c.MinIOBucket != "" {
+			_, err = mc.PutObject(ctx, c.MinIOBucket, key, bytes.NewReader(raw), int64(len(raw)), minio.PutObjectOptions{})
+			if err != nil {
+				log.Error().Err(err).Msg("put object")
+			}
+		}
+
+		m, err := mail.ReadMessage(bytes.NewReader(raw))
+		if err != nil {
+			log.Error().Err(err).Msg("parse message")
+			continue
+		}
+		subject := m.Header.Get("Subject")
+		from := m.Header.Get("From")
+		body, _ := io.ReadAll(m.Body)
+
+		var ticketID int64
+		re := regexp.MustCompile(`\[TKT-(\d+)\]`)
+		if match := re.FindStringSubmatch(subject); len(match) == 2 {
+			if n, err := strconv.Atoi(match[1]); err == nil {
+				if err := db.QueryRow(ctx, "select id from tickets where number=$1", n).Scan(&ticketID); err != nil {
+					ticketID = 0
+				}
+			}
+		}
+
+		if ticketID == 0 {
+			if err := db.QueryRow(ctx, "insert into tickets (title, description, status) values ($1,$2,'New') returning id", subject, string(body)).Scan(&ticketID); err != nil {
+				log.Error().Err(err).Msg("create ticket")
+				continue
+			}
+		} else {
+			if _, err := db.Exec(ctx, "insert into ticket_comments (ticket_id, body_md, is_internal) values ($1,$2,false)", ticketID, string(body)); err != nil {
+				log.Error().Err(err).Msg("insert comment")
+			}
+		}
+
+		parsed := map[string]string{
+			"subject": subject,
+			"from":    from,
+		}
+		pj, _ := json.Marshal(parsed)
+		if _, err := db.Exec(ctx, "insert into email_inbound (raw_store_key, parsed_json, status, ticket_id) values ($1,$2,'processed',$3)", key, pj, ticketID); err != nil {
+			log.Error().Err(err).Msg("insert email_inbound")
+		}
+
+		seq := new(imap.SeqSet)
+		seq.AddNum(msg.SeqNum)
+		if err := cli.Store(seq, imap.AddFlags, []interface{}{imap.SeenFlag}, nil); err != nil {
+			log.Error().Err(err).Msg("store flags")
+		}
+	}
+	return <-done
+}

--- a/worker/cmd/worker/main.go
+++ b/worker/cmd/worker/main.go
@@ -15,20 +15,31 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/joho/godotenv"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
 type Config struct {
-	DatabaseURL string
-	RedisAddr   string
-	Env         string
-	SMTPHost    string
-	SMTPPort    string
-	SMTPUser    string
-	SMTPPass    string
-	SMTPFrom    string
+	DatabaseURL   string
+	RedisAddr     string
+	Env           string
+	SMTPHost      string
+	SMTPPort      string
+	SMTPUser      string
+	SMTPPass      string
+	SMTPFrom      string
+	IMAPHost      string
+	IMAPUser      string
+	IMAPPass      string
+	IMAPFolder    string
+	MinIOEndpoint string
+	MinIOAccess   string
+	MinIOSecret   string
+	MinIOBucket   string
+	MinIOUseSSL   bool
 }
 
 func getEnv(key, def string) string {
@@ -41,14 +52,23 @@ func getEnv(key, def string) string {
 func cfg() Config {
 	_ = godotenv.Load()
 	return Config{
-		DatabaseURL: getEnv("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/helpdesk?sslmode=disable"),
-		RedisAddr:   getEnv("REDIS_ADDR", "localhost:6379"),
-		Env:         getEnv("ENV", "dev"),
-		SMTPHost:    getEnv("SMTP_HOST", ""),
-		SMTPPort:    getEnv("SMTP_PORT", "25"),
-		SMTPUser:    getEnv("SMTP_USER", ""),
-		SMTPPass:    getEnv("SMTP_PASS", ""),
-		SMTPFrom:    getEnv("SMTP_FROM", ""),
+		DatabaseURL:   getEnv("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/helpdesk?sslmode=disable"),
+		RedisAddr:     getEnv("REDIS_ADDR", "localhost:6379"),
+		Env:           getEnv("ENV", "dev"),
+		SMTPHost:      getEnv("SMTP_HOST", ""),
+		SMTPPort:      getEnv("SMTP_PORT", "25"),
+		SMTPUser:      getEnv("SMTP_USER", ""),
+		SMTPPass:      getEnv("SMTP_PASS", ""),
+		SMTPFrom:      getEnv("SMTP_FROM", ""),
+		IMAPHost:      getEnv("IMAP_HOST", ""),
+		IMAPUser:      getEnv("IMAP_USER", ""),
+		IMAPPass:      getEnv("IMAP_PASS", ""),
+		IMAPFolder:    getEnv("IMAP_FOLDER", "INBOX"),
+		MinIOEndpoint: getEnv("MINIO_ENDPOINT", ""),
+		MinIOAccess:   getEnv("MINIO_ACCESS_KEY", ""),
+		MinIOSecret:   getEnv("MINIO_SECRET_KEY", ""),
+		MinIOBucket:   getEnv("MINIO_BUCKET", ""),
+		MinIOUseSSL:   getEnv("MINIO_USE_SSL", "false") == "true",
 	}
 }
 
@@ -106,7 +126,7 @@ func sendEmail(c Config, j EmailJob) error {
 	if err != nil {
 		return fmt.Errorf("invalid To address: %w", err)
 	}
-	
+
 	sanitizedFrom, err := sanitizeAndValidateEmail(c.SMTPFrom)
 	if err != nil {
 		return fmt.Errorf("invalid From address: %w", err)
@@ -119,10 +139,10 @@ func sendEmail(c Config, j EmailJob) error {
 	if err := mailTemplates.ExecuteTemplate(&bodyBuf, j.Template+"_body", j.Data); err != nil {
 		return err
 	}
-	
+
 	// Sanitize the subject to prevent header injection
 	sanitizedSubject := sanitizeEmailHeader(subjBuf.String())
-	
+
 	msg := bytes.Buffer{}
 	msg.WriteString("From: " + sanitizedFrom + "\r\n")
 	msg.WriteString("To: " + sanitizedTo + "\r\n")
@@ -153,6 +173,28 @@ func main() {
 		log.Error().Err(err).Msg("redis ping failed (queue not active yet)")
 	}
 	defer rdb.Close()
+
+	var mc *minio.Client
+	if c.MinIOEndpoint != "" {
+		mc, err = minio.New(c.MinIOEndpoint, &minio.Options{
+			Creds:  credentials.NewStaticV4(c.MinIOAccess, c.MinIOSecret, ""),
+			Secure: c.MinIOUseSSL,
+		})
+		if err != nil {
+			log.Error().Err(err).Msg("minio init")
+		}
+	}
+
+	if c.IMAPHost != "" {
+		go func() {
+			for {
+				if err := pollIMAP(ctx, c, db, mc); err != nil {
+					log.Error().Err(err).Msg("poll imap")
+				}
+				time.Sleep(time.Minute)
+			}
+		}()
+	}
 
 	log.Info().Msg("worker started")
 	for {

--- a/worker/cmd/worker/main.go
+++ b/worker/cmd/worker/main.go
@@ -186,14 +186,18 @@ func main() {
 	}
 
 	if c.IMAPHost != "" {
-		go func() {
-			for {
-				if err := pollIMAP(ctx, c, db, mc); err != nil {
-					log.Error().Err(err).Msg("poll imap")
+		if mc == nil {
+			log.Error().Msg("IMAP polling requires MinIO, but MinIO client failed to initialize; IMAP polling will not start")
+		} else {
+			go func() {
+				for {
+					if err := pollIMAP(ctx, c, db, mc); err != nil {
+						log.Error().Err(err).Msg("poll imap")
+					}
+					time.Sleep(time.Minute)
 				}
-				time.Sleep(time.Minute)
-			}
-		}()
+			}()
+		}
 	}
 
 	log.Info().Msg("worker started")


### PR DESCRIPTION
## Summary
- poll IMAP mailbox for new messages and store raw emails
- link emails to existing tickets or create new tickets
- track inbound email metadata in database

## Testing
- `go test ./...` in `worker/cmd/worker`
- `go test ./...` in `api/cmd/api` *(fails: missing go.sum entry)*

------
https://chatgpt.com/codex/tasks/task_e_68b432e8af8c8322afe76511896060b7