### PR TITLE
Add IMAP polling worker job

### DIFF
--- a/worker/cmd/worker/email_security_test.go
+++ b/worker/cmd/worker/email_security_test.go
@@ -62,6 +62,14 @@ func TestSanitizeEmailHeader(t *testing.T) {
 	}
 }
 
+func TestSanitizeEmailBody(t *testing.T) {
+	input := []byte("<script>alert('xss')</script><p>Hello</p>")
+	expected := "<p>Hello</p>"
+	if result := sanitizeEmailBody(input); result != expected {
+		t.Errorf("sanitizeEmailBody() = %q, want %q", result, expected)
+	}
+}
+
 func TestValidateEmailAddress(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -178,7 +186,7 @@ func TestSanitizeAndValidateEmail(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := sanitizeAndValidateEmail(tt.email)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("sanitizeAndValidateEmail(%q) expected error but got none", tt.email)

--- a/worker/cmd/worker/go.mod
+++ b/worker/cmd/worker/go.mod
@@ -1,24 +1,44 @@
 module github.com/you/helpdesk/worker
 
-go 1.23
+go 1.23.0
+
+toolchain go1.24.3
 
 require (
+	github.com/emersion/go-imap v1.2.1
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/joho/godotenv v1.5.1
+	github.com/microcosm-cc/bluemonday v1.0.27
+	github.com/minio/minio-go/v7 v7.0.95
 	github.com/redis/go-redis/v9 v9.5.1
 	github.com/rs/zerolog v1.32.0
 )
 
 require (
+	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21 // indirect
+	github.com/go-ini/ini v1.67.0 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/gorilla/css v1.0.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.11 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
-	golang.org/x/crypto v0.17.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
+	github.com/minio/crc64nvme v1.0.2 // indirect
+	github.com/minio/md5-simd v1.1.2 // indirect
+	github.com/philhofer/fwd v1.2.0 // indirect
+	github.com/rs/xid v1.6.0 // indirect
+	github.com/tinylib/msgp v1.3.0 // indirect
+	golang.org/x/crypto v0.39.0 // indirect
+	golang.org/x/net v0.41.0 // indirect
+	golang.org/x/sync v0.15.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/text v0.26.0 // indirect
 )

--- a/worker/cmd/worker/imap.go
+++ b/worker/cmd/worker/imap.go
@@ -84,7 +84,11 @@ func pollIMAP(ctx context.Context, c Config, db *pgxpool.Pool, mc *minio.Client)
 		}
 		subject := m.Header.Get("Subject")
 		from := m.Header.Get("From")
-		body, _ := io.ReadAll(m.Body)
+		body, err := io.ReadAll(m.Body)
+		if err != nil {
+			log.Error().Err(err).Msg("read message body")
+			continue
+		}
 		cleanBody := sanitizeEmailBody(body)
 
 		var ticketID int64

--- a/worker/cmd/worker/imap.go
+++ b/worker/cmd/worker/imap.go
@@ -112,7 +112,11 @@ func pollIMAP(ctx context.Context, c Config, db *pgxpool.Pool, mc *minio.Client)
 			"subject": subject,
 			"from":    from,
 		}
-		pj, _ := json.Marshal(parsed)
+		pj, err := json.Marshal(parsed)
+		if err != nil {
+			log.Error().Err(err).Msg("marshal parsed email")
+			continue
+		}
 		if _, err := db.Exec(ctx, "insert into email_inbound (raw_store_key, parsed_json, status, ticket_id) values ($1,$2,'processed',$3)", key, pj, ticketID); err != nil {
 			log.Error().Err(err).Msg("insert email_inbound")
 		}

--- a/worker/cmd/worker/imap.go
+++ b/worker/cmd/worker/imap.go
@@ -20,6 +20,9 @@ import (
 
 // pollIMAP connects to an IMAP inbox, retrieves new messages and stores them.
 func pollIMAP(ctx context.Context, c Config, db *pgxpool.Pool, mc *minio.Client) error {
+	if mc == nil {
+		return fmt.Errorf("MinIO client is nil")
+	}
 	addr := fmt.Sprintf("%s:993", c.IMAPHost)
 	cli, err := imapclient.DialTLS(addr, nil)
 	if err != nil {

--- a/worker/cmd/worker/imap.go
+++ b/worker/cmd/worker/imap.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/mail"
+	"regexp"
+	"strconv"
+
+	"github.com/emersion/go-imap"
+	imapclient "github.com/emersion/go-imap/client"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/minio/minio-go/v7"
+	"github.com/rs/zerolog/log"
+)
+
+// pollIMAP connects to an IMAP inbox, retrieves new messages and stores them.
+func pollIMAP(ctx context.Context, c Config, db *pgxpool.Pool, mc *minio.Client) error {
+	addr := fmt.Sprintf("%s:993", c.IMAPHost)
+	cli, err := imapclient.DialTLS(addr, nil)
+	if err != nil {
+		return err
+	}
+	defer cli.Logout()
+
+	if err := cli.Login(c.IMAPUser, c.IMAPPass); err != nil {
+		return err
+	}
+
+	mbox, err := cli.Select(c.IMAPFolder, false)
+	if err != nil {
+		return err
+	}
+	if mbox.Messages == 0 {
+		return nil
+	}
+
+	criteria := imap.NewSearchCriteria()
+	criteria.WithoutFlags = []string{imap.SeenFlag}
+	uids, err := cli.Search(criteria)
+	if err != nil || len(uids) == 0 {
+		return err
+	}
+
+	seqset := new(imap.SeqSet)
+	seqset.AddNum(uids...)
+	section := &imap.BodySectionName{}
+	messages := make(chan *imap.Message, 10)
+	done := make(chan error, 1)
+	go func() {
+		done <- cli.Fetch(seqset, []imap.FetchItem{imap.FetchEnvelope, section.FetchItem()}, messages)
+	}()
+
+	for msg := range messages {
+		if msg == nil {
+			continue
+		}
+		r := msg.GetBody(section)
+		if r == nil {
+			continue
+		}
+		raw, err := io.ReadAll(r)
+		if err != nil {
+			log.Error().Err(err).Msg("read body")
+			continue
+		}
+
+		key := fmt.Sprintf("email/%s.eml", uuid.NewString())
+		if mc != nil && c.MinIOBucket != "" {
+			_, err = mc.PutObject(ctx, c.MinIOBucket, key, bytes.NewReader(raw), int64(len(raw)), minio.PutObjectOptions{})
+			if err != nil {
+				log.Error().Err(err).Msg("put object")
+			}
+		}
+
+		m, err := mail.ReadMessage(bytes.NewReader(raw))
+		if err != nil {
+			log.Error().Err(err).Msg("parse message")
+			continue
+		}
+		subject := m.Header.Get("Subject")
+		from := m.Header.Get("From")
+		body, _ := io.ReadAll(m.Body)
+		cleanBody := sanitizeEmailBody(body)
+
+		var ticketID int64
+		re := regexp.MustCompile(`\[TKT-(\d+)\]`)
+		if match := re.FindStringSubmatch(subject); len(match) == 2 {
+			if n, err := strconv.Atoi(match[1]); err == nil {
+				if err := db.QueryRow(ctx, "select id from tickets where number=$1", n).Scan(&ticketID); err != nil {
+					ticketID = 0
+				}
+			}
+		}
+
+		if ticketID == 0 {
+			if err := db.QueryRow(ctx, "insert into tickets (title, description, status) values ($1,$2,'New') returning id", subject, cleanBody).Scan(&ticketID); err != nil {
+				log.Error().Err(err).Msg("create ticket")
+				continue
+			}
+		} else {
+			if _, err := db.Exec(ctx, "insert into ticket_comments (ticket_id, body_md, is_internal) values ($1,$2,false)", ticketID, cleanBody); err != nil {
+				log.Error().Err(err).Msg("insert comment")
+			}
+		}
+
+		parsed := map[string]string{
+			"subject": subject,
+			"from":    from,
+		}
+		pj, _ := json.Marshal(parsed)
+		if _, err := db.Exec(ctx, "insert into email_inbound (raw_store_key, parsed_json, status, ticket_id) values ($1,$2,'processed',$3)", key, pj, ticketID); err != nil {
+			log.Error().Err(err).Msg("insert email_inbound")
+		}
+
+		seq := new(imap.SeqSet)
+		seq.AddNum(msg.SeqNum)
+		if err := cli.Store(seq, imap.AddFlags, []interface{}{imap.SeenFlag}, nil); err != nil {
+			log.Error().Err(err).Msg("store flags")
+		}
+	}
+	return <-done
+}


### PR DESCRIPTION
## Summary
- poll IMAP mailbox for new messages and store raw emails
- link emails to existing tickets or create new tickets
- track inbound email metadata in database
- sanitize email bodies before saving to tickets or comments

## Testing
- `go test ./...` in `api/cmd/api`
- `go test ./...` in `worker/cmd/worker`


------
https://chatgpt.com/codex/tasks/task_e_68b432e8af8c8322afe76511896060b7