### PR TITLE
Add SLA business time calculation and expose status

### DIFF
--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -595,8 +595,8 @@ func (a *App) getTicket(c *gin.Context) {
 			PolicyID:             *policyID,
 			ResponseElapsedMS:    derefInt64(respMS),
 			ResolutionElapsedMS:  derefInt64(resMS),
-			ResponseTargetMins:   int(derefInt32(respTarget)),
-			ResolutionTargetMins: int(derefInt32(resTarget)),
+			ResponseTargetMins:   int(derefInt32(resTarget)),
+			ResolutionTargetMins: int(derefInt32(respTarget)),
 			Paused:               paused != nil && *paused,
 			Reason:               reason,
 		}

--- a/worker/cmd/worker/main.go
+++ b/worker/cmd/worker/main.go
@@ -271,6 +271,7 @@ func updateSLAClocks(ctx context.Context, db *pgxpool.Pool) error {
 		var lastStarted time.Time
 		var respTarget, resTarget int
 		if err := rows.Scan(&ticketID, &calID, &respMS, &resMS, &lastStarted, &respTarget, &resTarget); err != nil {
+			log.Error().Err(err).Msg("failed to scan row in updateSLAClocks")
 			continue
 		}
 		if calID == "" {

--- a/worker/cmd/worker/main.go
+++ b/worker/cmd/worker/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
-	"github.com/you/helpdesk/worker/sla"
+	"example.com/yourrepo/worker/sla"
 )
 
 type Config struct {

--- a/worker/cmd/worker/sla/sla.go
+++ b/worker/cmd/worker/sla/sla.go
@@ -1,0 +1,112 @@
+package sla
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type DB interface {
+	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
+}
+
+type Hours struct {
+	StartSec int
+	EndSec   int
+}
+
+type Calendar struct {
+	Location *time.Location
+	Hours    map[time.Weekday]Hours
+	Holidays map[time.Time]struct{}
+}
+
+func LoadCalendar(ctx context.Context, db DB, id string) (*Calendar, error) {
+	var tz string
+	if err := db.QueryRow(ctx, "select tz from calendars where id=$1", id).Scan(&tz); err != nil {
+		return nil, err
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, err
+	}
+	cal := &Calendar{
+		Location: loc,
+		Hours:    make(map[time.Weekday]Hours),
+		Holidays: make(map[time.Time]struct{}),
+	}
+	rows, err := db.Query(ctx, "select dow, start_sec, end_sec from business_hours where calendar_id=$1", id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var dow, start, end int
+		if err := rows.Scan(&dow, &start, &end); err == nil {
+			cal.Hours[time.Weekday(dow)] = Hours{StartSec: start, EndSec: end}
+		}
+	}
+	hrows, err := db.Query(ctx, "select date from holidays where calendar_id=$1", id)
+	if err != nil {
+		return nil, err
+	}
+	defer hrows.Close()
+	for hrows.Next() {
+		var d time.Time
+		if err := hrows.Scan(&d); err == nil {
+			day := time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, loc)
+			cal.Holidays[day] = struct{}{}
+		}
+	}
+	return cal, nil
+}
+
+func (c *Calendar) BusinessDuration(start, end time.Time) time.Duration {
+	if end.Before(start) {
+		start, end = end, start
+	}
+	start = start.In(c.Location)
+	end = end.In(c.Location)
+	total := time.Duration(0)
+	cur := start
+	for cur.Before(end) {
+		dayStart := time.Date(cur.Year(), cur.Month(), cur.Day(), 0, 0, 0, 0, c.Location)
+		dayEnd := dayStart.Add(24 * time.Hour)
+		if _, ok := c.Holidays[dayStart]; ok {
+			cur = dayEnd
+			continue
+		}
+		hrs, ok := c.Hours[dayStart.Weekday()]
+		if !ok {
+			cur = dayEnd
+			continue
+		}
+		bhStart := dayStart.Add(time.Duration(hrs.StartSec) * time.Second)
+		bhEnd := dayStart.Add(time.Duration(hrs.EndSec) * time.Second)
+		if cur.Before(bhStart) {
+			cur = bhStart
+		}
+		if cur.After(bhEnd) {
+			cur = dayEnd
+			continue
+		}
+		e := minTime(end, bhEnd)
+		if e.After(cur) {
+			total += e.Sub(cur)
+		}
+		cur = e
+		if cur.Equal(bhEnd) {
+			cur = dayEnd
+		}
+	}
+	return total
+}
+
+func minTime(a, b time.Time) time.Time {
+	if a.Before(b) {
+		return a
+	}
+	return b
+}

--- a/worker/cmd/worker/sla/sla_test.go
+++ b/worker/cmd/worker/sla/sla_test.go
@@ -1,0 +1,46 @@
+package sla
+
+import (
+	"testing"
+	"time"
+)
+
+func testCalendar() *Calendar {
+	loc, _ := time.LoadLocation("America/New_York")
+	hrs := Hours{StartSec: 9 * 3600, EndSec: 17 * 3600}
+	return &Calendar{
+		Location: loc,
+		Hours: map[time.Weekday]Hours{
+			time.Monday:    hrs,
+			time.Tuesday:   hrs,
+			time.Wednesday: hrs,
+			time.Thursday:  hrs,
+			time.Friday:    hrs,
+		},
+		Holidays: map[time.Time]struct{}{},
+	}
+}
+
+func TestBusinessDurationBasic(t *testing.T) {
+	cal := testCalendar()
+	loc := cal.Location
+	start := time.Date(2024, 7, 1, 16, 0, 0, 0, loc) // Mon 4pm
+	end := time.Date(2024, 7, 2, 10, 0, 0, 0, loc)   // Tue 10am
+	d := cal.BusinessDuration(start, end)
+	if d != 2*time.Hour {
+		t.Fatalf("expected 2h got %v", d)
+	}
+}
+
+func TestBusinessDurationHoliday(t *testing.T) {
+	cal := testCalendar()
+	loc := cal.Location
+	holiday := time.Date(2024, 7, 4, 0, 0, 0, 0, loc)
+	cal.Holidays[holiday] = struct{}{}
+	start := time.Date(2024, 7, 3, 16, 0, 0, 0, loc)
+	end := time.Date(2024, 7, 5, 10, 0, 0, 0, loc)
+	d := cal.BusinessDuration(start, end)
+	if d != 2*time.Hour {
+		t.Fatalf("expected 2h got %v", d)
+	}
+}


### PR DESCRIPTION
## Summary
- add calendar-aware business time calculator for SLAs
- worker periodically updates `ticket_sla_clocks` and logs breaches
- API exposes SLA status fields on ticket responses

## Testing
- `go test -run TestHealthz -count=1` in `api/cmd/api`
- `go test -v ./sla -run TestBusinessDuration -count=1` in `worker/cmd/worker`
- `go test -v ./...` in `worker/cmd/worker`


------
https://chatgpt.com/codex/tasks/task_e_68b4ab4b6b348322b73fc8ac49d601b7