### PR TITLE
ci: add Docker build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Run tests
+        run: TEST_BYPASS_AUTH=true go test -cover ./...
+      - name: Build API image
+        run: docker build -f Dockerfile.api -t helpdesk-api .
+      - name: Build worker image
+        run: docker build -f Dockerfile.worker -t helpdesk-worker .
+      - uses: azure/setup-helm@v3
+        with:
+          version: v3.13.3
+      - name: Lint Helm chart
+        run: helm lint helm/helpdesk
+      - name: Package Helm chart
+        run: helm package helm/helpdesk

--- a/README.md
+++ b/README.md
@@ -25,6 +25,28 @@ A minimal FootPrints-style ticketing system scaffold in Go, with PostgreSQL migr
    curl http://localhost:8080/healthz
    ```
 
+## Local Development
+
+- Build binaries:
+  ```bash
+  cd cmd/api && go build -o ../../bin/api
+  cd cmd/worker && go build -o ../../bin/worker
+  ```
+- Run unit tests:
+  ```bash
+  TEST_BYPASS_AUTH=true go test -cover ./...
+  ```
+- Build Docker images:
+  ```bash
+  docker build -f Dockerfile.api -t helpdesk-api .
+  docker build -f Dockerfile.worker -t helpdesk-worker .
+  ```
+- Helm chart checks:
+  ```bash
+  helm lint helm/helpdesk
+  helm package helm/helpdesk
+  ```
+
 ## API (MVP)
 - `GET /healthz`
 - `GET /me` (authenticated user info and roles)
@@ -50,3 +72,7 @@ A minimal FootPrints-style ticketing system scaffold in Go, with PostgreSQL migr
 - Unit tests can bypass JWT validation by setting `TEST_BYPASS_AUTH=true`. This injects a synthetic user with the `agent` role so auth-protected routes can be exercised without a JWKS.
 - Handlers depend on a database interface and an object storage interface, enabling mocks/fakes in tests without external services.
 - Run all tests from repo root: `go test ./...`
+
+## Continuous Integration
+
+GitHub Actions builds the API and worker images, runs `TEST_BYPASS_AUTH=true go test -cover ./...`, and lints and packages the Helm chart on every push and pull request.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow building API and worker images, running Go tests, and linting/packaging the Helm chart
- document local development commands and CI behavior in README

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./...` *(fails: missing go.sum entries)*
- `helm lint helm/helpdesk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c21359888322bba675544ec620cc