### PR TITLE
ci: pin Go 1.23 and run API tests from component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
-      - name: Run tests
-        run: TEST_BYPASS_AUTH=true go test -cover ./...
+          go-version: '1.23'
+      - name: Run API tests
+        run: |
+          cd cmd/api
+          go mod tidy
+          TEST_BYPASS_AUTH=true go test -v .
       - name: Build API image
         run: docker build -f Dockerfile.api -t helpdesk-api .
       - name: Build worker image

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ A minimal FootPrints-style ticketing system scaffold in Go, with PostgreSQL migr
 
 - Build binaries:
   ```bash
-  cd cmd/api && go build -o ../../bin/api
-  cd cmd/worker && go build -o ../../bin/worker
+  cd cmd/api && go mod tidy && go build -o ../../bin/api
+  cd cmd/worker && go mod tidy && go build -o ../../bin/worker
   ```
-- Run unit tests:
+- Run unit tests (API only):
   ```bash
-  TEST_BYPASS_AUTH=true go test -cover ./...
+  cd cmd/api && go mod tidy && TEST_BYPASS_AUTH=true go test -v .
   ```
 - Build Docker images:
   ```bash
@@ -75,4 +75,4 @@ A minimal FootPrints-style ticketing system scaffold in Go, with PostgreSQL migr
 
 ## Continuous Integration
 
-GitHub Actions builds the API and worker images, runs `TEST_BYPASS_AUTH=true go test -cover ./...`, and lints and packages the Helm chart on every push and pull request.
+GitHub Actions builds the API and worker images, runs `cd cmd/api && go mod tidy && TEST_BYPASS_AUTH=true go test -v .`, and lints and packages the Helm chart on every push and pull request.


### PR DESCRIPTION
## Summary
- pin Go version to 1.23 in CI
- tidy modules and run API tests from `cmd/api`
- document `go mod tidy` in local build and test instructions

## Testing
- `go mod tidy`
- `cd cmd/api && go mod tidy && TEST_BYPASS_AUTH=true go test -v .` *(hangs with no output; interrupted after ~3m)*

------
https://chatgpt.com/codex/tasks/task_e_68b4eaff2cc48322973bca101387b1b2