### PR TITLE
api: add ticket filters and search

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -430,13 +430,9 @@ func (a *App) listTickets(c *gin.Context) {
 		i++
 	}
 	if v := strings.TrimSpace(c.Query("search")); v != "" {
-		terms := strings.Fields(v)
-		if len(terms) > 0 {
-			q := strings.Join(terms, " & ")
-			where = append(where, fmt.Sprintf("to_tsvector('english', coalesce(t.title,'') || ' ' || coalesce(t.description,'')) @@ to_tsquery('english', $%d)", i))
-			args = append(args, q)
-			i++
-		}
+		where = append(where, fmt.Sprintf("to_tsvector('english', coalesce(t.title,'') || ' ' || coalesce(t.description,'')) @@ websearch_to_tsquery('english', $%d)", i))
+		args = append(args, v)
+		i++
 	}
 
 	if len(where) > 0 {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -430,9 +430,8 @@ func (a *App) listTickets(c *gin.Context) {
 		i++
 	}
 	if v := strings.TrimSpace(c.Query("search")); v != "" {
-		q := strings.ReplaceAll(v, " ", " & ")
-		where = append(where, fmt.Sprintf("to_tsvector('english', coalesce(t.title,'') || ' ' || coalesce(t.description,'')) @@ to_tsquery('english', $%d)", i))
-		args = append(args, q)
+		where = append(where, fmt.Sprintf("to_tsvector('english', coalesce(t.title,'') || ' ' || coalesce(t.description,'')) @@ websearch_to_tsquery('english', $%d)", i))
+		args = append(args, v)
 		i++
 	}
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -430,9 +430,13 @@ func (a *App) listTickets(c *gin.Context) {
 		i++
 	}
 	if v := strings.TrimSpace(c.Query("search")); v != "" {
-		where = append(where, fmt.Sprintf("to_tsvector('english', coalesce(t.title,'') || ' ' || coalesce(t.description,'')) @@ websearch_to_tsquery('english', $%d)", i))
-		args = append(args, v)
-		i++
+		terms := strings.Fields(v)
+		if len(terms) > 0 {
+			q := strings.Join(terms, " & ")
+			where = append(where, fmt.Sprintf("to_tsvector('english', coalesce(t.title,'') || ' ' || coalesce(t.description,'')) @@ to_tsquery('english', $%d)", i))
+			args = append(args, q)
+			i++
+		}
 	}
 
 	if len(where) > 0 {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -392,16 +393,56 @@ type SLAStatus struct {
 // ===== Handlers =====
 func (a *App) listTickets(c *gin.Context) {
 	ctx := c.Request.Context()
-	rows, err := a.db.Query(ctx, `
+
+	base := `
        select t.id, t.number, t.title, coalesce(t.description,''), t.requester_id, t.assignee_id, t.team_id, t.priority,
               t.urgency, t.category, t.subcategory, t.status, t.scheduled_at, t.due_at, t.source, t.custom_json, t.created_at, t.updated_at,
               sc.policy_id, sc.response_elapsed_ms, sc.resolution_elapsed_ms, sc.paused, sc.reason,
               sp.response_target_mins, sp.resolution_target_mins
        from tickets t
        left join ticket_sla_clocks sc on sc.ticket_id = t.id
-       left join sla_policies sp on sp.id = sc.policy_id
-       order by t.created_at desc
-       limit 200`)
+       left join sla_policies sp on sp.id = sc.policy_id`
+
+	where := []string{}
+	args := []any{}
+	i := 1
+
+	if v := c.Query("status"); v != "" {
+		where = append(where, fmt.Sprintf("t.status = $%d", i))
+		args = append(args, v)
+		i++
+	}
+	if v := c.Query("priority"); v != "" {
+		if p, err := strconv.Atoi(v); err == nil {
+			where = append(where, fmt.Sprintf("t.priority = $%d", i))
+			args = append(args, p)
+			i++
+		}
+	}
+	if v := c.Query("team"); v != "" {
+		where = append(where, fmt.Sprintf("t.team_id = $%d", i))
+		args = append(args, v)
+		i++
+	}
+	if v := c.Query("assignee"); v != "" {
+		where = append(where, fmt.Sprintf("t.assignee_id = $%d", i))
+		args = append(args, v)
+		i++
+	}
+	if v := strings.TrimSpace(c.Query("search")); v != "" {
+		q := strings.ReplaceAll(v, " ", " & ")
+		where = append(where, fmt.Sprintf("to_tsvector('english', coalesce(t.title,'') || ' ' || coalesce(t.description,'')) @@ to_tsquery('english', $%d)", i))
+		args = append(args, q)
+		i++
+	}
+
+	if len(where) > 0 {
+		base += "\n       where " + strings.Join(where, " and ")
+	}
+
+	base += "\n       order by t.created_at desc\n       limit 200"
+
+	rows, err := a.db.Query(ctx, base, args...)
 	if err != nil {
 		c.JSON(500, gin.H{"error": err.Error()})
 		return

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -124,47 +124,65 @@ func (db *recordDB) Exec(ctx context.Context, sql string, args ...interface{}) (
 	return pgconn.CommandTag{}, nil
 }
 
-func TestListTickets_FilteringAndSearch(t *testing.T) {
-	db := &recordDB{}
-	cfg := Config{Env: "test", TestBypassAuth: true}
-	app := NewApp(cfg, db, nil, nil, nil)
+func TestListTickets(t *testing.T) {
+	cases := []struct {
+		name         string
+		url          string
+		wantSQLParts []string
+		wantArgs     []any
+	}{
+		{
+			name: "filtering and search",
+			url:  "/tickets?status=open&priority=2&team=team1&assignee=user1&search=foo+++bar",
+			wantSQLParts: []string{
+				"t.status = $1",
+				"t.priority = $2",
+				"t.team_id = $3",
+				"t.assignee_id = $4",
+				"to_tsquery('english', $5)",
+			},
+			wantArgs: []any{"open", 2, "team1", "user1", "foo & bar"},
+		},
+		{
+			name:         "search only",
+			url:          "/tickets?search=hello+++world",
+			wantSQLParts: []string{"to_tsquery('english', $1)"},
+			wantArgs:     []any{"hello & world"},
+		},
+		{
+			name:         "filters only",
+			url:          "/tickets?status=open&priority=1",
+			wantSQLParts: []string{"t.status = $1", "t.priority = $2"},
+			wantArgs:     []any{"open", 1},
+		},
+	}
 
-	rr := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/tickets?status=open&priority=2&team=team1&assignee=user1&search=foo+bar", nil)
-	app.r.ServeHTTP(rr, req)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := &recordDB{}
+			cfg := Config{Env: "test", TestBypassAuth: true}
+			app := NewApp(cfg, db, nil, nil, nil)
 
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rr.Code)
-	}
-	if !strings.Contains(db.sql, "t.status = $1") || !strings.Contains(db.sql, "t.priority = $2") ||
-		!strings.Contains(db.sql, "t.team_id = $3") || !strings.Contains(db.sql, "t.assignee_id = $4") ||
-		!strings.Contains(db.sql, "to_tsquery('english', $5)") {
-		t.Fatalf("unexpected sql: %s", db.sql)
-	}
-	if len(db.args) != 5 {
-		t.Fatalf("expected 5 args, got %d", len(db.args))
-	}
-	if db.args[0] != "open" || db.args[1] != 2 || db.args[2] != "team1" || db.args[3] != "user1" || db.args[4] != "foo & bar" {
-		t.Fatalf("unexpected args: %#v", db.args)
-	}
-}
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			app.r.ServeHTTP(rr, req)
 
-func TestListTickets_SearchOnly(t *testing.T) {
-	db := &recordDB{}
-	cfg := Config{Env: "test", TestBypassAuth: true}
-	app := NewApp(cfg, db, nil, nil, nil)
-
-	rr := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/tickets?search=hello+world", nil)
-	app.r.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rr.Code)
-	}
-	if !strings.Contains(db.sql, "to_tsquery('english', $1)") {
-		t.Fatalf("expected to_tsquery in sql: %s", db.sql)
-	}
-	if len(db.args) != 1 || db.args[0] != "hello & world" {
-		t.Fatalf("unexpected args: %#v", db.args)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rr.Code)
+			}
+			for _, part := range tc.wantSQLParts {
+				if !strings.Contains(db.sql, part) {
+					t.Fatalf("missing sql part %q in %s", part, db.sql)
+				}
+			}
+			if len(db.args) != len(tc.wantArgs) {
+				t.Fatalf("expected %d args, got %d", len(tc.wantArgs), len(db.args))
+			}
+			for i, v := range tc.wantArgs {
+				if db.args[i] != v {
+					t.Fatalf("arg %d = %#v, want %#v", i, db.args[i], v)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- allow listing tickets filtered by status, priority, team, assignee
- add `search` query using PostgreSQL full-text search
- test listTickets filtering and search

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./...`

------
https://chatgpt.com/codex/tasks/task_e_68b503e4d1b88322bdc6ac580d39efe6