### PR TITLE
web: include requester and priority in ticket creation

### DIFF
--- a/web/requester/src/api.ts
+++ b/web/requester/src/api.ts
@@ -3,6 +3,8 @@ export interface Ticket {
   title: string;
   description: string;
   status: string;
+  requester_id?: string;
+  priority?: number;
   created_at?: string;
   category?: string;
 }

--- a/web/requester/src/components/TicketForm.tsx
+++ b/web/requester/src/components/TicketForm.tsx
@@ -20,7 +20,17 @@ export default function TicketForm({ initial = {}, hideTitle, hideCategory }: Pr
 
   async function submit(e: FormEvent) {
     e.preventDefault();
-    const t = await createTicket({ title, description, status: 'New', category }, auth.user?.access_token || '');
+    const t = await createTicket(
+      {
+        title,
+        description,
+        status: 'New',
+        category,
+        requester_id: auth.user?.profile.sub || '',
+        priority: 3,
+      },
+      auth.user?.access_token || '',
+    );
     nav(`/tickets/${t.id}`);
   }
 


### PR DESCRIPTION
## Summary
- include `requester_id` and `priority` fields in Ticket interface
- send authenticated requester ID and default priority when creating tickets

## Testing
- `npm run build`
- `go test -cover ./...` *(fails: arg 4 = "foo   bar", want "foo & bar")*

------
https://chatgpt.com/codex/tasks/task_e_68b5169790848322b61e1e71797a0c35