### PR TITLE
web/requester: fix ticket comment fetching and submission

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -234,6 +234,7 @@ func (a *App) routes() {
 	auth.POST("/tickets", a.createTicket)
 	auth.GET("/tickets/:id", a.getTicket)
 	auth.PATCH("/tickets/:id", a.requireRole("agent"), a.updateTicket)
+	auth.GET("/tickets/:id/comments", a.listComments)
 	auth.POST("/tickets/:id/comments", a.addComment)
 	auth.GET("/tickets/:id/attachments", a.listAttachments)
 	auth.POST("/tickets/:id/attachments", a.uploadAttachment)
@@ -388,6 +389,15 @@ type SLAStatus struct {
 	ResolutionTargetMins int     `json:"resolution_target_mins"`
 	Paused               bool    `json:"paused"`
 	Reason               *string `json:"reason,omitempty"`
+}
+
+type Comment struct {
+	ID         string    `json:"id"`
+	TicketID   string    `json:"ticket_id"`
+	AuthorID   string    `json:"author_id"`
+	BodyMD     string    `json:"body_md"`
+	IsInternal bool      `json:"is_internal"`
+	CreatedAt  time.Time `json:"created_at"`
 }
 
 // ===== Handlers =====
@@ -718,6 +728,36 @@ type commentReq struct {
 	BodyMD     string `json:"body_md" binding:"required"`
 	IsInternal bool   `json:"is_internal"`
 	AuthorID   string `json:"author_id" binding:"required"`
+}
+
+func (a *App) listComments(c *gin.Context) {
+	id := c.Param("id")
+	ctx := c.Request.Context()
+	rows, err := a.db.Query(ctx, `
+       select id, ticket_id, author_id, body_md, is_internal, created_at
+       from ticket_comments
+       where ticket_id=$1 and is_internal=false
+       order by created_at
+    `, id)
+	if err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	defer rows.Close()
+	var cs []Comment
+	for rows.Next() {
+		var cm Comment
+		if err := rows.Scan(&cm.ID, &cm.TicketID, &cm.AuthorID, &cm.BodyMD, &cm.IsInternal, &cm.CreatedAt); err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
+		cs = append(cs, cm)
+	}
+	if err := rows.Err(); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(200, cs)
 }
 
 func (a *App) addComment(c *gin.Context) {

--- a/web/requester/src/api.ts
+++ b/web/requester/src/api.ts
@@ -15,6 +15,7 @@ export interface Comment {
   author_id?: string;
   body_md: string;
   created_at?: string;
+  is_internal?: boolean;
 }
 
 const API_BASE = import.meta.env.VITE_API_BASE || '/api';
@@ -50,10 +51,16 @@ export async function listComments(id: string, token: string): Promise<Comment[]
   return apiFetch(`/tickets/${id}/comments`, {}, token);
 }
 
-export async function addComment(id: string, body_md: string, token: string): Promise<Comment> {
+export interface CommentInput {
+  body_md: string;
+  author_id: string;
+  is_internal: boolean;
+}
+
+export async function addComment(id: string, data: CommentInput, token: string): Promise<Comment> {
   return apiFetch(`/tickets/${id}/comments`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ body_md }),
+    body: JSON.stringify(data),
   }, token);
 }

--- a/web/requester/src/components/TicketDetail.tsx
+++ b/web/requester/src/components/TicketDetail.tsx
@@ -21,10 +21,18 @@ export default function TicketDetail() {
 
   async function submit(e: FormEvent) {
     e.preventDefault();
-    if (id) {
-      await addComment(id, body, auth.user?.access_token || '');
+    if (id && auth.user) {
+      await addComment(
+        id,
+        {
+          body_md: body,
+          author_id: auth.user.profile.sub || '',
+          is_internal: false,
+        },
+        auth.user.access_token,
+      );
       setBody('');
-      const c = await listComments(id, auth.user?.access_token || '');
+      const c = await listComments(id, auth.user.access_token);
       setComments(c);
     }
   }


### PR DESCRIPTION
## Summary
- expose `GET /tickets/:id/comments` endpoint
- send author and visibility when adding comments in requester UI

## Testing
- `npm run build`
- `go test -cover ./...` (fails: arg 4 = "foo   bar", want "foo & bar")

------
https://chatgpt.com/codex/tasks/task_e_68b517f6d11483229f616f79661ddbd7