### PR TITLE
fix: register CSAT endpoint for GET requests

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -228,7 +228,7 @@ func main() {
 
 func (a *App) routes() {
 	a.r.GET("/healthz", func(c *gin.Context) { c.JSON(200, gin.H{"ok": true}) })
-	a.r.POST("/csat/:token", a.submitCSAT)
+	a.r.GET("/csat/:token", a.submitCSAT)
 
 	auth := a.r.Group("/")
 	auth.Use(a.authMiddleware())

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -132,7 +132,7 @@ func TestSubmitCSAT(t *testing.T) {
 	app := NewApp(cfg, db, nil, nil, nil)
 
 	rr := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/csat/token123?score=good", nil)
+	req := httptest.NewRequest(http.MethodGet, "/csat/token123?score=good", nil)
 	app.r.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusOK {

--- a/helpdesk_platform_foot_prints_style_mvp_design_spec.md
+++ b/helpdesk_platform_foot_prints_style_mvp_design_spec.md
@@ -201,7 +201,7 @@
 - `POST /search` (advanced)
 - `GET /me` | `GET /teams` | `GET /slas` | `GET /kb?query`
 - `POST /exports/tickets` (CSV async → download URL)
-- `POST /csat/{token}` (public)
+- `GET /csat/{token}` (public)
 - `POST /webhooks/email-inbound` (if using SMTP hook)
 
 **WebSockets:** presence, ticket updates, queue counters, typing, notifications.


### PR DESCRIPTION
## Summary
- allow CSAT ratings via GET to match email survey links
- update CSAT unit test and design spec

## Testing
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b5200af0188322829c040ee2e1a4c1