### PR TITLE
docs: OpenAPI spec + README/API docs refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,39 @@
 
 A minimal FootPrints-style ticketing system scaffold in Go, with PostgreSQL migrations and a Helm chart for Kubernetes.
 
-## What you get
-- Go API service (Gin) with basic ticket endpoints
-- Embedded SQL migrations (goose) for Postgres (JSONB custom fields, FTS index)
-- Dockerfiles for API & Worker
-- Helm chart skeleton (api + worker deployments, service, ingress, config)
+## What You Get
+- Go API service (Gin): tickets, comments, attachments, watchers, exports, metrics.
+- Embedded SQL migrations (goose) for Postgres (JSONB custom fields, FTS index, CSAT columns).
+- Redis-driven worker: email notifications (SMTP), SLA clock updates, optional IMAP poller.
+- Object storage: S3-compatible (MinIO) or local filesystem for attachments.
+- Web apps: agent workspace (`web/agent`) and requester portal (`web/requester`).
+- Dockerfiles for API & Worker and a Helm chart (deployments, service, ingress, config).
 
 ## Quickstart (local, Docker Compose-free)
-1. Provision Postgres 14+ and create a db (e.g., `helpdesk`). Save the URL:
+1. Provision Postgres 14+ and create a db (e.g., `helpdesk`). Set env:
    ```
    export DATABASE_URL=postgres://user:pass@localhost:5432/helpdesk?sslmode=disable
+   # Optional/Dev: enable local auth with cookie-based JWT
+   export AUTH_MODE=local
+   export AUTH_LOCAL_SECRET=dev-secret
+   # Optional: use local filesystem for attachments (instead of MinIO)
+   export FILESTORE_PATH=$PWD/data
+   # Optional: Redis for worker/metrics (API logs if missing)
+   export REDIS_ADDR=localhost:6379
    ```
-2. Build API:
+2. Build and run API:
    ```bash
-   cd cmd/api
-   go mod tidy
-   go build -o ../../bin/api
+   cd cmd/api && go mod tidy && go build -o ../../bin/api
    ../../bin/api
    ```
-3. Hit health:
+3. Health check:
    ```
    curl http://localhost:8080/healthz
    ```
+
+Notes:
+- In `AUTH_MODE=local` and `ENV=dev`, an admin user is auto-seeded. Set `ADMIN_PASSWORD` to control it; otherwise a random password is generated and logged once.
+- For MinIO, set `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_BUCKET`, `MINIO_USE_SSL` and omit `FILESTORE_PATH`.
 
 ## Local Development
 
@@ -32,9 +43,9 @@ A minimal FootPrints-style ticketing system scaffold in Go, with PostgreSQL migr
   cd cmd/api && go mod tidy && go build -o ../../bin/api
   cd cmd/worker && go mod tidy && go build -o ../../bin/worker
   ```
-- Run unit tests (API only):
+- Run tests (all packages):
   ```bash
-  cd cmd/api && go mod tidy && TEST_BYPASS_AUTH=true go test -v .
+  TEST_BYPASS_AUTH=true go test -cover ./...
   ```
 - Build Docker images:
   ```bash
@@ -47,14 +58,19 @@ A minimal FootPrints-style ticketing system scaffold in Go, with PostgreSQL migr
   helm package helm/helpdesk
   ```
 
-## API (MVP)
+## API Endpoints
 - `GET /healthz`
-- `GET /me` (authenticated user info and roles)
-- `GET /tickets`
-- `POST /tickets`  (title, description, priority, urgency, category, subcategory, custom_json)
-- `GET /tickets/:id`
-- `PATCH /tickets/:id` (status, assignee_id, priority, urgency, scheduled_at, due_at, custom_json)
-- `POST /tickets/:id/comments` (body_md, is_internal)
+- Auth (local mode): `POST /login`, `POST /logout`
+- `GET /me` – authenticated user info and roles
+- Tickets: `GET /tickets` (filters: `status,priority,team,assignee,search`), `POST /tickets`, `GET /tickets/:id`, `PATCH /tickets/:id`
+- Comments: `GET /tickets/:id/comments`, `POST /tickets/:id/comments`
+- Attachments: `GET /tickets/:id/attachments`, `POST /tickets/:id/attachments`, `DELETE /tickets/:id/attachments/:attID`
+- Watchers: `GET /tickets/:id/watchers`, `POST /tickets/:id/watchers`, `DELETE /tickets/:id/watchers/:userID`
+- Exports: `POST /exports/tickets` (CSV)
+- CSAT: `GET /csat/:token?score=good|bad` (public)
+- Metrics (agent role): `GET /metrics/sla`, `GET /metrics/resolution`, `GET /metrics/tickets`
+
+See `docs/api.md` for detailed status codes, request/response bodies, and models. For tooling and client generation, use the OpenAPI spec at `docs/openapi.yaml`. For metrics visualization guidance, see `docs/grafana.md`.
 
 ## Helm (Kubernetes)
 1. Set values in `helm/helpdesk/values.yaml` (hostnames, secrets, external DB/Redis/MinIO).
@@ -64,15 +80,93 @@ A minimal FootPrints-style ticketing system scaffold in Go, with PostgreSQL migr
    ```
 
 ### Notes
-- Auth uses OIDC JWTs with role checks (agents required for ticket updates).
-- Worker service is scaffolded but not wired to a queue yet.
+- Auth supports OIDC (JWKS) and a dev-friendly local mode (`AUTH_MODE=local`). `TEST_BYPASS_AUTH=true` bypasses JWTs in tests.
+- Worker consumes Redis jobs, sends SMTP email using templates in `cmd/worker/templates/`, updates SLA clocks, and can poll IMAP if configured.
+- Object storage is optional; when unconfigured, set `FILESTORE_PATH` to store attachments locally.
 - This is a starter kit—intended to be iterated on.
 
 ### Testing
 - Unit tests can bypass JWT validation by setting `TEST_BYPASS_AUTH=true`. This injects a synthetic user with the `agent` role so auth-protected routes can be exercised without a JWKS.
-- Handlers depend on a database interface and an object storage interface, enabling mocks/fakes in tests without external services.
+- Handlers depend on database and object storage interfaces, enabling fakes in tests without external services.
 - Run all tests from repo root: `go test ./...`
 
 ## Continuous Integration
 
-GitHub Actions builds the API and worker images, runs `cd cmd/api && go mod tidy && TEST_BYPASS_AUTH=true go test -v .`, and lints and packages the Helm chart on every push and pull request.
+GitHub Actions builds the API and worker images, runs tests (`TEST_BYPASS_AUTH=true go test ./...`), and lints/packages the Helm chart on every push and pull request.
+
+## Docker Compose
+- Start stack (Postgres, Redis, API, Worker):
+  ```bash
+  docker compose up -d db redis api worker
+  ```
+- Agent UI (optional dev server):
+  ```bash
+  docker compose up web
+  ```
+- Default ports: API `http://localhost:8080`, Agent UI `http://localhost:5173`, Postgres `5432`, Redis `6379`.
+- Filesystem attachments are stored under `./data` (mounted to `/data`) when `FILESTORE_PATH` is used.
+- Compose uses `AUTH_MODE=local` for quick start and seeds an admin (set `ADMIN_PASSWORD`).
+
+## Environment Variables
+
+API (cmd/api):
+- `ADDR`: bind address (default `:8080`).
+- `ENV`: `dev` or `prod`.
+- `DATABASE_URL`: Postgres connection string.
+- `REDIS_ADDR`: Redis address (optional but recommended).
+- `OIDC_ISSUER`, `OIDC_JWKS_URL`: OIDC settings for JWT validation.
+- `AUTH_MODE`: `oidc` or `local`.
+- `AUTH_LOCAL_SECRET`: HMAC secret for local auth cookie JWTs.
+- `ADMIN_PASSWORD`: initial admin password in dev local-auth mode.
+- `FILESTORE_PATH`: local path for attachments (filesystem store).
+- `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_BUCKET`, `MINIO_USE_SSL`: S3/MinIO settings.
+- `TEST_BYPASS_AUTH`: set `true` in tests to bypass JWT and inject a test user.
+
+Worker (cmd/worker):
+- `DATABASE_URL`, `REDIS_ADDR`, `ENV`.
+- SMTP: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`.
+- IMAP (optional): `IMAP_HOST`, `IMAP_USER`, `IMAP_PASS`, `IMAP_FOLDER`.
+- MinIO/S3: `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_BUCKET`, `MINIO_USE_SSL`.
+
+Web – Agent (web/agent):
+- `VITE_API_TARGET`: API origin for dev proxy (defaults to `http://localhost:8080`).
+
+Web – Requester (web/requester):
+- `VITE_API_BASE`: API base path (default `/api`).
+- `VITE_OIDC_AUTHORITY`: OIDC provider URL.
+- `VITE_OIDC_CLIENT_ID`: OIDC client ID.
+
+## Web Apps
+
+Agent Workspace (React):
+- Dev server:
+  ```bash
+  cd web/agent
+  npm install
+  # optional: point to a non-default API origin
+  VITE_API_TARGET=http://localhost:8080 npm run dev
+  ```
+  Open `http://localhost:5173`. The dev server proxies `/api` to `VITE_API_TARGET`.
+
+Requester Portal (React):
+- Dev server:
+  ```bash
+  cd web/requester
+  npm install
+  export VITE_API_BASE=/api
+  export VITE_OIDC_AUTHORITY=... 
+  export VITE_OIDC_CLIENT_ID=...
+  npm run dev
+  ```
+  See `web/requester/README.md` for details.
+
+Compose-based UI:
+- `docker compose up web` runs the agent dev server in a container with `VITE_API_TARGET` set to the API service.
+
+## Troubleshooting
+- Postgres connection/migrations: ensure `DATABASE_URL` is correct and the DB is reachable. Migrations auto-run at startup; logs will show goose errors if any.
+- Redis unavailable: the API/worker log a ping error but continue; features that enqueue/process jobs may be no-ops until Redis is up.
+- Attachments/uploads: configure either MinIO (`MINIO_*`) or a local path via `FILESTORE_PATH`. Permission issues on `FILESTORE_PATH` can cause 500s.
+- Exports URL: ticket export uploads require an object store. With MinIO configured, the response includes a URL. With filesystem store, a public URL is not generated.
+- Auth errors: for OIDC, set `OIDC_JWKS_URL` (and `OIDC_ISSUER` if enforcing issuer). For local auth, set `AUTH_LOCAL_SECRET` and optionally `ADMIN_PASSWORD`.
+- Port conflicts: default ports are 8080 (API), 5173 (Agent UI), 5432 (Postgres), 6379 (Redis). Adjust `ADDR` or container port mappings as needed.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,69 @@
+# API Reference
+
+This document describes the HTTP API exposed by the Helpdesk service. Unless noted as public, endpoints require authentication. In production, use OIDC (JWKS). For development, `AUTH_MODE=local` enables cookie-based login via `/login`.
+
+Base URL examples:
+- Local API: `http://localhost:8080`
+- Agent dev server proxy: requests to `/api/...` are proxied to the API in dev.
+
+## Authentication
+- OIDC (default): Send `Authorization: Bearer <JWT>`. The API validates against `OIDC_JWKS_URL` and optional `OIDC_ISSUER`.
+- Local (dev): `POST /login` issues an HttpOnly cookie. Include cookie on subsequent requests. `POST /logout` clears it.
+
+## Conventions
+- Content type: JSON unless specified.
+- Time format: RFC3339.
+- Errors: `{ "error": "message" }`.
+
+## Endpoints
+
+Health
+- GET `/healthz` → 200 OK `{ "ok": true }`
+
+Auth (local mode only)
+- POST `/login` body `{ username, password }` → 200 OK `{ ok:true }` | 400 | 401 | 500
+- POST `/logout` → 200 OK `{ ok:true }`
+
+User
+- GET `/me` → 200 `{ id, external_id, email, display_name, roles }` | 401
+
+Tickets
+- GET `/tickets` query `status,priority,team,assignee,search` → 200 `[Ticket]` | 500
+- POST `/tickets` body `{ title, description, requester_id, priority, urgency?, category?, subcategory?, custom_json? }` → 201 `{ id, number, status }` | 400 | 500
+- GET `/tickets/:id` → 200 `Ticket` | 404
+- PATCH `/tickets/:id` (agent role) body partial `{ status?, assignee_id?, priority?, urgency?, scheduled_at?, due_at?, custom_json? }` → 200 `{ ok:true }` | 400 | 500
+
+Comments
+- GET `/tickets/:id/comments` → 200 `[Comment]` | 500
+- POST `/tickets/:id/comments` body `{ body_md, is_internal, author_id }` → 201 `{ id }` | 400 | 500
+
+Attachments
+- GET `/tickets/:id/attachments` → 200 `[{ id, filename, bytes, mime, created_at }]` | 500
+- POST `/tickets/:id/attachments` multipart field `file` → 201 `{ id }` | 400 | 500
+- DELETE `/tickets/:id/attachments/:attID` → 200 `{ ok:true }` | 404 | 500
+
+Watchers
+- GET `/tickets/:id/watchers` → 200 `[user_id]` | 500
+- POST `/tickets/:id/watchers` body `{ user_id }` → 201 `{ ok:true }` | 400 | 500
+- DELETE `/tickets/:id/watchers/:userID` → 200 `{ ok:true }` | 500
+
+Customer Satisfaction (CSAT)
+- GET `/csat/:token?score=good|bad` (public) → 200 `{ ok:true }` | 400 | 404 | 500
+
+Exports
+- POST `/exports/tickets` (agent role) body `{ ids: [uuid] }` → 200 `{ url }` | 400 | 500
+  - Requires configured object store. For MinIO/S3, `url` points to the uploaded CSV. With filesystem store, prefer fetching the file via your own mechanism since no HTTP endpoint serves it.
+
+Metrics (agent role)
+- GET `/metrics/sla` → 200 `{ total, met, sla_attainment }` | 500
+- GET `/metrics/resolution` → 200 `{ avg_resolution_ms }` | 500
+- GET `/metrics/tickets` → 200 `{ daily: [{ day, count }] }` | 500
+
+## Models
+
+Ticket
+- Fields: `id, number, title, description, requester_id, assignee_id?, team_id?, priority, urgency?, category?, subcategory?, status, scheduled_at?, due_at?, source, custom_json, created_at, updated_at, sla?`
+
+Comment
+- Fields: `id, ticket_id, author_id, body_md, is_internal, created_at`
+

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,575 @@
+openapi: 3.0.3
+info:
+  title: Helpdesk API
+  version: 0.1.0
+  description: >-
+    Minimal ticketing API. Uses OIDC bearer JWTs in production, or HttpOnly cookie auth in local mode.
+servers:
+  - url: http://localhost:8080
+    description: Local API
+tags:
+  - name: Health
+  - name: Auth
+  - name: Users
+  - name: Tickets
+  - name: Comments
+  - name: Attachments
+  - name: Watchers
+  - name: CSAT
+  - name: Metrics
+  - name: Exports
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: auth
+  schemas:
+    AuthUser:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        external_id: { type: string }
+        email: { type: string, format: email }
+        display_name: { type: string }
+        roles:
+          type: array
+          items: { type: string }
+    Ticket:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        number: { type: string }
+        title: { type: string }
+        description: { type: string }
+        requester_id: { type: string, format: uuid }
+        assignee_id: { type: string, format: uuid, nullable: true }
+        team_id: { type: string, format: uuid, nullable: true }
+        priority: { type: integer, minimum: 1, maximum: 4 }
+        urgency: { type: integer, minimum: 1, maximum: 4, nullable: true }
+        category: { type: string, nullable: true }
+        subcategory: { type: string, nullable: true }
+        status: { type: string }
+        scheduled_at: { type: string, format: date-time, nullable: true }
+        due_at: { type: string, format: date-time, nullable: true }
+        source: { type: string }
+        custom_json: { type: object }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+        sla:
+          $ref: '#/components/schemas/SLAStatus'
+    SLAStatus:
+      type: object
+      properties:
+        policy_id: { type: string, format: uuid }
+        response_elapsed_ms: { type: integer }
+        resolution_elapsed_ms: { type: integer }
+        response_target_mins: { type: integer }
+        resolution_target_mins: { type: integer }
+        paused: { type: boolean }
+        reason: { type: string, nullable: true }
+    Comment:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        ticket_id: { type: string, format: uuid }
+        author_id: { type: string, format: uuid }
+        body_md: { type: string }
+        is_internal: { type: boolean }
+        created_at: { type: string, format: date-time }
+    Attachment:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        filename: { type: string }
+        bytes: { type: integer, format: int64 }
+        mime: { type: string, nullable: true }
+        created_at: { type: string, format: date-time }
+    CreateTicketRequest:
+      type: object
+      required: [title, requester_id, priority]
+      properties:
+        title: { type: string }
+        description: { type: string }
+        requester_id: { type: string, format: uuid }
+        priority: { type: integer, minimum: 1, maximum: 4 }
+        urgency: { type: integer, minimum: 1, maximum: 4 }
+        category: { type: string }
+        subcategory: { type: string }
+        custom_json: { type: object }
+    UpdateTicketRequest:
+      type: object
+      properties:
+        status: { type: string }
+        assignee_id: { type: string, format: uuid }
+        priority: { type: integer, minimum: 1, maximum: 4 }
+        urgency: { type: integer, minimum: 1, maximum: 4 }
+        scheduled_at: { type: string, format: date-time }
+        due_at: { type: string, format: date-time }
+        custom_json: { type: object }
+    CommentRequest:
+      type: object
+      required: [body_md, author_id]
+      properties:
+        body_md: { type: string }
+        is_internal: { type: boolean }
+        author_id: { type: string, format: uuid }
+    WatcherRequest:
+      type: object
+      required: [user_id]
+      properties:
+        user_id: { type: string, format: uuid }
+    ExportTicketsRequest:
+      type: object
+      required: [ids]
+      properties:
+        ids:
+          type: array
+          items: { type: string, format: uuid }
+paths:
+  /healthz:
+    get:
+      tags: [Health]
+      summary: Health check
+      security: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+  /login:
+    post:
+      tags: [Auth]
+      summary: Login (local mode)
+      description: Enabled only when `AUTH_MODE=local`.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [username, password]
+              properties:
+                username: { type: string }
+                password: { type: string }
+      responses:
+        '200': { description: OK }
+        '400': { description: Bad Request }
+        '401': { description: Unauthorized }
+        '500': { description: Server Error }
+  /logout:
+    post:
+      tags: [Auth]
+      summary: Logout (local mode)
+      security: []
+      responses:
+        '200': { description: OK }
+  /me:
+    get:
+      tags: [Users]
+      summary: Current user
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthUser'
+        '401': { description: Unauthorized }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+  /tickets:
+    get:
+      tags: [Tickets]
+      summary: List tickets
+      parameters:
+        - in: query
+          name: status
+          schema: { type: string }
+        - in: query
+          name: priority
+          schema: { type: integer }
+        - in: query
+          name: team
+          schema: { type: string, format: uuid }
+        - in: query
+          name: assignee
+          schema: { type: string, format: uuid }
+        - in: query
+          name: search
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Ticket' }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+    post:
+      tags: [Tickets]
+      summary: Create ticket
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateTicketRequest' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string, format: uuid }
+                  number: { type: string }
+                  status: { type: string }
+        '400': { description: Bad Request }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+  /tickets/{id}:
+    get:
+      tags: [Tickets]
+      summary: Get ticket
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Ticket' }
+        '404': { description: Not Found }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+    patch:
+      tags: [Tickets]
+      summary: Update ticket
+      description: Requires `agent` role.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/UpdateTicketRequest' }
+      responses:
+        '200': { description: OK }
+        '400': { description: Bad Request }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+  /tickets/{id}/comments:
+    get:
+      tags: [Comments]
+      summary: List public comments
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Comment' }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+    post:
+      tags: [Comments]
+      summary: Add comment
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CommentRequest' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string, format: uuid }
+        '400': { description: Bad Request }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+  /tickets/{id}/attachments:
+    get:
+      tags: [Attachments]
+      summary: List attachments
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Attachment' }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+    post:
+      tags: [Attachments]
+      summary: Upload attachment
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string, format: uuid }
+        '400': { description: Bad Request }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+  /tickets/{id}/attachments/{attID}:
+    delete:
+      tags: [Attachments]
+      summary: Delete attachment
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+        - in: path
+          name: attID
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200': { description: OK }
+        '404': { description: Not Found }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+  /tickets/{id}/watchers:
+    get:
+      tags: [Watchers]
+      summary: List watcher user IDs
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { type: string, format: uuid }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+    post:
+      tags: [Watchers]
+      summary: Add watcher
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/WatcherRequest' }
+      responses:
+        '201': { description: Created }
+        '400': { description: Bad Request }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+  /tickets/{id}/watchers/{userID}:
+    delete:
+      tags: [Watchers]
+      summary: Remove watcher
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+        - in: path
+          name: userID
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200': { description: OK }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+  /csat/{token}:
+    get:
+      tags: [CSAT]
+      summary: Submit CSAT score
+      description: Public endpoint embedded in emails.
+      security: []
+      parameters:
+        - in: path
+          name: token
+          required: true
+          schema: { type: string }
+        - in: query
+          name: score
+          required: true
+          schema:
+            type: string
+            enum: [good, bad]
+      responses:
+        '200': { description: OK }
+        '400': { description: Invalid score }
+        '404': { description: Invalid token }
+        '500': { description: Server Error }
+  /metrics/sla:
+    get:
+      tags: [Metrics]
+      summary: SLA attainment
+      description: Requires `agent` role.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total: { type: integer }
+                  met: { type: integer }
+                  sla_attainment: { type: number }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+  /metrics/resolution:
+    get:
+      tags: [Metrics]
+      summary: Average resolution time
+      description: Requires `agent` role.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  avg_resolution_ms: { type: number }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+  /metrics/tickets:
+    get:
+      tags: [Metrics]
+      summary: Ticket volume per day (30)
+      description: Requires `agent` role.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  daily:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        day: { type: string, format: date }
+                        count: { type: integer }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+  /exports/tickets:
+    post:
+      tags: [Exports]
+      summary: Export tickets to CSV
+      description: Requires object store configuration. Requires `agent` role.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ExportTicketsRequest' }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url: { type: string, format: uri }
+        '400': { description: Bad Request }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+


### PR DESCRIPTION
Adds docs/api.md and docs/openapi.yaml, updates README with Docker Compose, env vars, web apps, and troubleshooting. Test plan: validate endpoints against server handlers; run TEST_BYPASS_AUTH=true go test -cover ./...; optional: npx @redocly/cli lint docs/openapi.yaml.