### PR TITLE
docs(ui)+ci: ReDoc at /docs and OpenAPI validation

### DIFF
--- a/.github/workflows/openapi-validate.yml
+++ b/.github/workflows/openapi-validate.yml
@@ -1,0 +1,27 @@
+name: OpenAPI Validate
+
+on:
+  pull_request:
+    paths:
+      - 'docs/openapi.yaml'
+      - '.github/workflows/openapi-validate.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/openapi.yaml'
+      - '.github/workflows/openapi-validate.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Lint with Redocly CLI
+        run: npx -y @redocly/cli@latest lint docs/openapi.yaml
+      - name: Validate with swagger-cli
+        run: npx -y swagger-cli@4.0.4 validate docs/openapi.yaml

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Notes:
 - CSAT: `GET /csat/:token?score=good|bad` (public)
 - Metrics (agent role): `GET /metrics/sla`, `GET /metrics/resolution`, `GET /metrics/tickets`
 
-See `docs/api.md` for detailed status codes, request/response bodies, and models. For tooling and client generation, use the OpenAPI spec at `docs/openapi.yaml`. For metrics visualization guidance, see `docs/grafana.md`.
+See `docs/api.md` for detailed status codes, request/response bodies, and models. For tooling and client generation, use `docs/openapi.yaml`. A live documentation UI is served at `/docs` when the API is running. For metrics visualization guidance, see `docs/grafana.md`.
 
 ## Helm (Kubernetes)
 1. Set values in `helm/helpdesk/values.yaml` (hostnames, secrets, external DB/Redis/MinIO).


### PR DESCRIPTION
API: Serve ReDoc at /docs and embed docs/openapi.yaml at /openapi.yaml.\nCI: Add GitHub Actions workflow to lint (Redocly) and validate (swagger-cli) OpenAPI spec on PRs and pushes.\n\nTest plan:\n- Run API locally, open http://localhost:8080/docs, verify UI loads and displays spec.\n- curl http://localhost:8080/openapi.yaml returns YAML.\n- CI validates docs/openapi.yaml (see workflow openapi-validate).