### PR TITLE
requester: add ticket priority and attachment fields

### DIFF
--- a/web/requester/src/api.ts
+++ b/web/requester/src/api.ts
@@ -5,8 +5,10 @@ export interface Ticket {
   status: string;
   requester_id?: string;
   priority?: number;
+  urgency?: number;
   created_at?: string;
   category?: string;
+  subcategory?: string;
 }
 
 export interface Comment {
@@ -63,4 +65,10 @@ export async function addComment(id: string, data: CommentInput, token: string):
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   }, token);
+}
+
+export async function uploadAttachment(id: string, file: File, token: string): Promise<void> {
+  const form = new FormData();
+  form.append('file', file);
+  await apiFetch(`/tickets/${id}/attachments`, { method: 'POST', body: form }, token);
 }

--- a/web/requester/src/components/TicketForm.tsx
+++ b/web/requester/src/components/TicketForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import type { FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from 'react-oidc-context';
-import { createTicket } from '../api';
+import { createTicket, uploadAttachment } from '../api';
 import type { Ticket } from '../api';
 
 interface Props {
@@ -14,7 +14,11 @@ interface Props {
 export default function TicketForm({ initial = {}, hideTitle, hideCategory }: Props) {
   const [title, setTitle] = useState(initial.title || '');
   const [description, setDescription] = useState(initial.description || '');
-  const [category, setCategory] = useState((initial as any).category || '');
+  const [category, setCategory] = useState(initial.category || '');
+  const [subcategory, setSubcategory] = useState(initial.subcategory || '');
+  const [priority, setPriority] = useState(initial.priority ?? 3);
+  const [urgency, setUrgency] = useState(initial.urgency ?? 3);
+  const [attachment, setAttachment] = useState<File | null>(null);
   const nav = useNavigate();
   const auth = useAuth();
 
@@ -26,11 +30,16 @@ export default function TicketForm({ initial = {}, hideTitle, hideCategory }: Pr
         description,
         status: 'New',
         category,
+        subcategory,
         requester_id: auth.user?.profile.sub || '',
-        priority: 3,
+        priority,
+        urgency,
       },
       auth.user?.access_token || '',
     );
+    if (attachment) {
+      await uploadAttachment(t.id, attachment, auth.user?.access_token || '');
+    }
     nav(`/tickets/${t.id}`);
   }
 
@@ -52,6 +61,32 @@ export default function TicketForm({ initial = {}, hideTitle, hideCategory }: Pr
           <input value={category} onChange={(e) => setCategory(e.target.value)} />
         </div>
       )}
+      <div>
+        <label>Subcategory</label>
+        <input value={subcategory} onChange={(e) => setSubcategory(e.target.value)} />
+      </div>
+      <div>
+        <label>Priority</label>
+        <select value={priority} onChange={(e) => setPriority(Number(e.target.value))}>
+          <option value={1}>1 - Critical</option>
+          <option value={2}>2 - High</option>
+          <option value={3}>3 - Medium</option>
+          <option value={4}>4 - Low</option>
+        </select>
+      </div>
+      <div>
+        <label>Urgency</label>
+        <select value={urgency} onChange={(e) => setUrgency(Number(e.target.value))}>
+          <option value={1}>1 - Critical</option>
+          <option value={2}>2 - High</option>
+          <option value={3}>3 - Medium</option>
+          <option value={4}>4 - Low</option>
+        </select>
+      </div>
+      <div>
+        <label>Attachment</label>
+        <input type="file" onChange={(e) => setAttachment(e.target.files?.[0] || null)} />
+      </div>
       <button type="submit">Submit</button>
     </form>
   );


### PR DESCRIPTION
## Summary
- allow requester ticket form to set priority, urgency, and subcategory
- add attachment picker and upload after ticket creation
- extend requester API with urgency/subcategory fields and attachment upload helper

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `go test ./...` (hangs with no output)


------
https://chatgpt.com/codex/tasks/task_e_68b54d24c90083229cac8da16e686675