### PR TITLE
web: map comment body from API field

### DIFF
--- a/web/agent/src/api.ts
+++ b/web/agent/src/api.ts
@@ -39,7 +39,7 @@ export async function fetchTickets(): Promise<Ticket[]> {
   }));
 }
 
-// No GET comments endpoint exists yet; return empty for now
+// Fetch comments for a ticket
 export async function fetchComments(ticketId: string): Promise<Comment[]> {
   const res = await fetch(`${API_BASE}/tickets/${ticketId}/comments`, {
     credentials: 'include',
@@ -55,7 +55,7 @@ export async function fetchComments(ticketId: string): Promise<Comment[]> {
   const data = await res.json();
   return (data as Array<Record<string, unknown>>).map((c) => ({
     id: String(c.id),
-    body: String(c.body),
+    body: String(c.body_md),
   }));
 }
 


### PR DESCRIPTION
## Summary
- map ticket comment body from `body_md` field so agent UI renders markdown

## Testing
- `npx eslint src/api.ts src/components/TicketWorkspace.tsx`
- `npm run lint` (fails: Unexpected any in TicketQueue.tsx)
- `TEST_BYPASS_AUTH=true go test -cover ./...` (hangs)


------
https://chatgpt.com/codex/tasks/task_e_68b556364d64832280b147e18abe4742