### PR TITLE
ci: publish images on tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  push-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - name: api
+            file: Dockerfile.api
+          - name: worker
+            file: Dockerfile.worker
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push ${{ matrix.name }} image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.file }}
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}-${{ matrix.name }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}-${{ matrix.name }}:latest


### PR DESCRIPTION
## Summary
- add workflow to build and push API and worker images to ghcr on release tags

## Testing
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b56f9bb1d48322823671716920b6b7