### PR TITLE
settings: add placeholder routes and forms

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -370,6 +370,9 @@ func (a *App) routes() {
 	auth.GET("/me", a.me)
 
 	auth.POST("/test-connection", a.requireRole("admin"), a.testConnection)
+	auth.POST("/settings/storage", a.requireRole("admin"), a.saveStorageSettings)
+	auth.POST("/settings/oidc", a.requireRole("admin"), a.saveOIDCSettings)
+	auth.POST("/settings/mail", a.requireRole("admin"), a.saveMailSettings)
 
 	auth.GET("/users/:id/roles", a.requireRole("admin"), a.listUserRoles)
 	auth.POST("/users/:id/roles", a.requireRole("admin"), a.addUserRole)
@@ -398,6 +401,18 @@ func (a *App) routes() {
 func (a *App) testConnection(c *gin.Context) {
 	log.Info().Msg("test connection")
 	c.JSON(http.StatusOK, gin.H{"ok": true, "log_path": a.cfg.LogPath})
+}
+
+func (a *App) saveStorageSettings(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"ok": true, "message": "coming soon"})
+}
+
+func (a *App) saveOIDCSettings(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"ok": true, "message": "coming soon"})
+}
+
+func (a *App) saveMailSettings(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"ok": true, "message": "coming soon"})
 }
 
 func (a *App) docsUI(c *gin.Context) {

--- a/web/admin/package.json
+++ b/web/admin/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "antd": "^5.19.0"
   },
   "devDependencies": {
     "@types/react": "^19.1.10",

--- a/web/admin/src/App.tsx
+++ b/web/admin/src/App.tsx
@@ -1,11 +1,22 @@
 import React from 'react'
+import { Tabs } from 'antd'
 import UserRoles from './components/UserRoles'
 import TestConnection from './components/TestConnection'
+import StorageSettings from '../../internal/StorageSettings'
+import OIDCSettings from '../../internal/OIDCSettings'
+import MailSettings from '../../internal/MailSettings'
 
 export default function App() {
   return (
     <div>
       <h1>Admin</h1>
+      <Tabs
+        items={[
+          { key: 'storage', label: 'Storage', children: <StorageSettings /> },
+          { key: 'oidc', label: 'OIDC', children: <OIDCSettings /> },
+          { key: 'mail', label: 'SMTP/IMAP', children: <MailSettings /> },
+        ]}
+      />
       <UserRoles />
       <TestConnection />
     </div>

--- a/web/admin/tsconfig.app.json
+++ b/web/admin/tsconfig.app.json
@@ -19,5 +19,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src", "../internal"]
 }

--- a/web/internal/MailSettings.tsx
+++ b/web/internal/MailSettings.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Form, Input, Button, message } from 'antd'
+
+export default function MailSettings() {
+  const onFinish = async (values: any) => {
+    await fetch('/settings/mail', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(values),
+    })
+    message.success('Email settings coming soon')
+  }
+
+  return (
+    <Form layout="vertical" onFinish={onFinish}>
+      <Form.Item label="SMTP Host" name="smtp_host">
+        <Input />
+      </Form.Item>
+      <Form.Item label="IMAP Host" name="imap_host">
+        <Input />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">
+          Save
+        </Button>
+      </Form.Item>
+    </Form>
+  )
+}

--- a/web/internal/OIDCSettings.tsx
+++ b/web/internal/OIDCSettings.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Form, Input, Button, message } from 'antd'
+
+export default function OIDCSettings() {
+  const onFinish = async (values: any) => {
+    await fetch('/settings/oidc', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(values),
+    })
+    message.success('OIDC settings coming soon')
+  }
+
+  return (
+    <Form layout="vertical" onFinish={onFinish}>
+      <Form.Item label="Issuer" name="issuer">
+        <Input />
+      </Form.Item>
+      <Form.Item label="Client ID" name="client_id">
+        <Input />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">
+          Save
+        </Button>
+      </Form.Item>
+    </Form>
+  )
+}

--- a/web/internal/StorageSettings.tsx
+++ b/web/internal/StorageSettings.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Form, Input, Button, message } from 'antd'
+
+export default function StorageSettings() {
+  const onFinish = async (values: any) => {
+    await fetch('/settings/storage', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(values),
+    })
+    message.success('Storage settings coming soon')
+  }
+
+  return (
+    <Form layout="vertical" onFinish={onFinish}>
+      <Form.Item label="Endpoint" name="endpoint">
+        <Input />
+      </Form.Item>
+      <Form.Item label="Bucket" name="bucket">
+        <Input />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">
+          Save
+        </Button>
+      </Form.Item>
+    </Form>
+  )
+}


### PR DESCRIPTION
## Summary
- add mock storage, OIDC, and mail settings routes
- scaffold Ant Design settings forms in internal web app and render in admin

## Testing
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b66d6adfbc8322976f18a97169e06e