### PR TITLE
web/internal: refresh settings forms after async fetch

### DIFF
--- a/web/internal/src/components/MailSettings.tsx
+++ b/web/internal/src/components/MailSettings.tsx
@@ -1,10 +1,17 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Form, Input, Button, message } from 'antd';
 import { useSettings, useSaveMailSettings } from '../api';
 
 export default function MailSettings() {
+  const [form] = Form.useForm();
   const { data } = useSettings();
   const save = useSaveMailSettings();
+
+  useEffect(() => {
+    if ((data as any)?.mail) {
+      form.setFieldsValue((data as any).mail);
+    }
+  }, [data, form]);
 
   const onFinish = (values: any) => {
     save.mutate(values, {
@@ -14,7 +21,7 @@ export default function MailSettings() {
   };
 
   return (
-    <Form layout="vertical" onFinish={onFinish} initialValues={(data as any)?.mail}>
+    <Form form={form} layout="vertical" onFinish={onFinish}>
       <Form.Item label="SMTP Host" name="smtp_host">
         <Input />
       </Form.Item>

--- a/web/internal/src/components/OIDCSettings.tsx
+++ b/web/internal/src/components/OIDCSettings.tsx
@@ -1,10 +1,17 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Form, Input, Button, message } from 'antd';
 import { useSettings } from '../api';
 import { apiFetch } from '../../shared/api';
 
 export default function OIDCSettings() {
+  const [form] = Form.useForm();
   const { data } = useSettings();
+
+  useEffect(() => {
+    if ((data as any)?.oidc) {
+      form.setFieldsValue((data as any).oidc);
+    }
+  }, [data, form]);
 
   const onFinish = async (values: any) => {
     await apiFetch('/settings/oidc', {
@@ -16,7 +23,7 @@ export default function OIDCSettings() {
   };
 
   return (
-    <Form layout="vertical" onFinish={onFinish} initialValues={(data as any)?.oidc}>
+    <Form form={form} layout="vertical" onFinish={onFinish}>
       <Form.Item label="Issuer" name="issuer">
         <Input />
       </Form.Item>

--- a/web/internal/src/components/StorageSettings.tsx
+++ b/web/internal/src/components/StorageSettings.tsx
@@ -1,10 +1,17 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Form, Input, Button, message } from 'antd';
 import { useSettings } from '../api';
 import { apiFetch } from '../../shared/api';
 
 export default function StorageSettings() {
+  const [form] = Form.useForm();
   const { data } = useSettings();
+
+  useEffect(() => {
+    if ((data as any)?.storage) {
+      form.setFieldsValue((data as any).storage);
+    }
+  }, [data, form]);
 
   const onFinish = async (values: any) => {
     await apiFetch('/settings/storage', {
@@ -16,7 +23,7 @@ export default function StorageSettings() {
   };
 
   return (
-    <Form layout="vertical" onFinish={onFinish} initialValues={(data as any)?.storage}>
+    <Form form={form} layout="vertical" onFinish={onFinish}>
       <Form.Item label="Endpoint" name="endpoint">
         <Input />
       </Form.Item>


### PR DESCRIPTION
## Summary
- refresh Mail, OIDC, and Storage settings forms when async settings load

## Testing
- `go test -cover ./...`
- `cd web/internal && npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b67309733083229041b74b35242c85