### PR TITLE
internal: add reconnecting event stream

### DIFF
--- a/web/internal/src/components/TicketDetail.tsx
+++ b/web/internal/src/components/TicketDetail.tsx
@@ -11,7 +11,7 @@ export default function TicketDetail({ id }: Props) {
 
   useEffect(() => {
     const stop = subscribeEvents((ev: AppEvent) => {
-      if (ev.type === 'ticket_updated' && (ev.data as any)?.id === id) {
+      if (ev.type === 'ticket_updated' && String((ev.data as any)?.id) === id) {
         refetch();
       }
     }, setConnected);


### PR DESCRIPTION
## Summary
- add reconnecting EventSource helper
- refresh ticket list and detail on SSE updates with poll fallback
- show SSE connection status in UI
- match ticket IDs consistently for SSE detail updates

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./...` *(hangs: no output)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b67d1f53a483228fa8684e1787937e