### PR TITLE
web: add antd React 19 patch

### DIFF
--- a/web/admin/package-lock.json
+++ b/web/admin/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@ant-design/v5-patch-for-react-19": "^1.0.3",
-        "antd": "^5.19.0",
+        "antd": "^5.27.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },

--- a/web/admin/package.json
+++ b/web/admin/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "antd": "^5.19.0",
+    "antd": "^5.27.2",
     "@ant-design/v5-patch-for-react-19": "^1.0.3"
   },
   "devDependencies": {

--- a/web/agent/package-lock.json
+++ b/web/agent/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@ant-design/v5-patch-for-react-19": "^1.0.3",
-        "antd": "^5.21.0",
+        "antd": "^5.27.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -2093,9 +2093,9 @@
       }
     },
     "node_modules/antd": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-5.27.1.tgz",
-      "integrity": "sha512-jGMSdBN7hAMvPV27B4RhzZfL6n6yu8yDbo7oXrlJasaOqB7bSDPcjdEy1kXy3JPsny/Qazb1ykzRI4EfcByAPQ==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.27.2.tgz",
+      "integrity": "sha512-9pYRUTrumIEuulRwZijhcnL6ScBZ1X6Y3iJa67VyNhEZAiXtENA7AtggsnqdVclQIm0WL4ky76qUdWrVhDWF3g==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.2.1",

--- a/web/agent/package.json
+++ b/web/agent/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "antd": "^5.21.0",
+    "antd": "^5.27.2",
     "@ant-design/v5-patch-for-react-19": "^1.0.3"
   },
   "devDependencies": {

--- a/web/internal/package-lock.json
+++ b/web/internal/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/v5-patch-for-react-19": "^1.0.3",
         "@tanstack/react-query": "^5.85.6",
-        "antd": "^5.21.0",
+        "antd": "^5.27.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2"

--- a/web/internal/package.json
+++ b/web/internal/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "antd": "^5.21.0",
+    "antd": "^5.27.2",
     "@tanstack/react-query": "^5.85.6",
     "react-router-dom": "^7.8.2",
     "@ant-design/v5-patch-for-react-19": "^1.0.3"


### PR DESCRIPTION
## Summary
- add @ant-design/v5-patch-for-react-19 to agent, admin and internal web apps
- import React 19 patch at startup for each web app
- upgrade antd to 5.27.2 for agent, admin and internal web apps

## Testing
- `npm install` in `web/agent`
- `npm install` in `web/admin`
- `npm install` in `web/internal`
- `go test -cover ./internal/...`
- `go test -cover ./cmd/api`
- `go test -cover ./cmd/worker`


------
https://chatgpt.com/codex/tasks/task_e_68b6865e15bc8322b85bad405afa2e11