### PR TITLE
compose: bump web node image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - ./data:/data:Z
 
   web:
-    image: node:20
+    image: node:22
     working_dir: /app
     environment:
       VITE_API_TARGET: "http://api:8080"


### PR DESCRIPTION
## Summary
- use Node 22 for web service

## Testing
- `cd cmd/api && go mod tidy && go build -o ../../bin/api`
- `cd cmd/worker && go mod tidy && go build -o ../../bin/worker`
- `go test -cover ./...`
- `docker-compose up -d` *(fails: ConnectionRefusedError – docker daemon unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6880caf588322812fb96231a749ab