### PR TITLE
web/admin: add React Query provider

### DIFF
--- a/web/admin/package-lock.json
+++ b/web/admin/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@ant-design/v5-patch-for-react-19": "^1.0.3",
+        "@tanstack/react-query": "^5.85.6",
         "antd": "^5.27.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
@@ -1380,6 +1381,32 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.85.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.85.6.tgz",
+      "integrity": "sha512-hCj0TktzdCv2bCepIdfwqVwUVWb+GSHm1Jnn8w+40lfhQ3m7lCO7ADRUJy+2unxQ/nzjh2ipC6ye69NDW3l73g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.85.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.6.tgz",
+      "integrity": "sha512-VUAag4ERjh+qlmg0wNivQIVCZUrYndqYu3/wPCVZd4r0E+1IqotbeyGTc+ICroL/PqbpSaGZg02zSWYfcvxbdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.85.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/web/admin/package.json
+++ b/web/admin/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
+    "@tanstack/react-query": "^5.85.6",
     "antd": "^5.27.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"

--- a/web/admin/src/App.tsx
+++ b/web/admin/src/App.tsx
@@ -1,23 +1,28 @@
 import { Tabs } from 'antd'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import UserRoles from './components/UserRoles'
 import TestConnection from './components/TestConnection'
 import StorageSettings from '../../internal/src/components/admin/StorageSettings'
 import OIDCSettings from '../../internal/src/components/admin/OIDCSettings'
 import MailSettings from '../../internal/src/components/admin/MailSettings'
 
+const queryClient = new QueryClient()
+
 export default function App() {
   return (
-    <div>
-      <h1>Admin</h1>
-      <Tabs
-        items={[
-          { key: 'storage', label: 'Storage', children: <StorageSettings /> },
-          { key: 'oidc', label: 'OIDC', children: <OIDCSettings /> },
-          { key: 'mail', label: 'SMTP/IMAP', children: <MailSettings /> },
-        ]}
-      />
-      <UserRoles />
-      <TestConnection />
-    </div>
+    <QueryClientProvider client={queryClient}>
+      <div>
+        <h1>Admin</h1>
+        <Tabs
+          items={[
+            { key: 'storage', label: 'Storage', children: <StorageSettings /> },
+            { key: 'oidc', label: 'OIDC', children: <OIDCSettings /> },
+            { key: 'mail', label: 'SMTP/IMAP', children: <MailSettings /> },
+          ]}
+        />
+        <UserRoles />
+        <TestConnection />
+      </div>
+    </QueryClientProvider>
   )
 }


### PR DESCRIPTION
## Summary
- provide React Query client for admin frontend
- add @tanstack/react-query dependency

## Testing
- `cd web/admin && npm install`
- `cd web/internal && npm install`
- `cd web/admin && npm run build` *(fails: Cannot find module 'antd' or its corresponding type declarations)*
- `TEST_BYPASS_AUTH=true go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b68d76b1488322b5aac0fabea5b88a