### PR TITLE
api: persist settings in database

### DIFF
--- a/cmd/api/handlers/settings.go
+++ b/cmd/api/handlers/settings.go
@@ -95,7 +95,7 @@ func SaveStorageSettings(db DB) gin.HandlerFunc {
 			return
 		}
 		b, _ := json.Marshal(data)
-		if _, err := db.Exec(c.Request.Context(), "update settings set storage=$1 where id=1", b); err != nil {
+		if _, err := db.Exec(c.Request.Context(), "update settings set storage=$1::jsonb where id=1", string(b)); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
@@ -112,7 +112,7 @@ func SaveOIDCSettings(db DB) gin.HandlerFunc {
 			return
 		}
 		b, _ := json.Marshal(data)
-		if _, err := db.Exec(c.Request.Context(), "update settings set oidc=$1 where id=1", b); err != nil {
+		if _, err := db.Exec(c.Request.Context(), "update settings set oidc=$1::jsonb where id=1", string(b)); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
@@ -129,7 +129,7 @@ func SaveMailSettings(db DB) gin.HandlerFunc {
 			return
 		}
 		b, _ := json.Marshal(data)
-		if _, err := db.Exec(c.Request.Context(), "update settings set mail=$1 where id=1", b); err != nil {
+		if _, err := db.Exec(c.Request.Context(), "update settings set mail=$1::jsonb where id=1", string(b)); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}

--- a/cmd/api/handlers/settings.go
+++ b/cmd/api/handlers/settings.go
@@ -1,14 +1,23 @@
 package handlers
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
-// Settings holds configuration values stored in memory.
+// DB defines the database methods used by the settings handlers.
+type DB interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+// Settings represents persisted configuration values.
 type Settings struct {
 	Storage  map[string]string `json:"storage"`
 	OIDC     map[string]string `json:"oidc"`
@@ -17,77 +26,130 @@ type Settings struct {
 	LastTest string            `json:"last_test"`
 }
 
-var (
-	mu       sync.RWMutex
-	cfgStore = Settings{
-		Storage:  map[string]string{},
-		OIDC:     map[string]string{},
-		Mail:     map[string]string{},
-		LogPath:  "/config/logs",
-		LastTest: "",
+// InitSettings ensures a row exists and sets initial log path.
+func InitSettings(ctx context.Context, db DB, logPath string) {
+	if db == nil {
+		return
 	}
-)
-
-// InitSettings sets initial values like log path.
-func InitSettings(logPath string) {
-	mu.Lock()
-	defer mu.Unlock()
+	_, _ = db.Exec(ctx, "insert into settings (id, log_path) values (1, $1) on conflict (id) do nothing", logPath)
 	if logPath != "" {
-		cfgStore.LogPath = logPath
+		_, _ = db.Exec(ctx, "update settings set log_path=$1 where id=1", logPath)
 	}
 }
 
-// GetSettings returns the current configuration.
-func GetSettings(c *gin.Context) {
-	mu.RLock()
-	defer mu.RUnlock()
-	c.JSON(http.StatusOK, cfgStore)
+func loadSettings(ctx context.Context, db DB) (Settings, error) {
+	var s Settings
+	var storage, oidc, mail []byte
+	var lt *time.Time
+	row := db.QueryRow(ctx, "select storage, oidc, mail, log_path, last_test from settings where id=1")
+	err := row.Scan(&storage, &oidc, &mail, &s.LogPath, &lt)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			s.Storage = map[string]string{}
+			s.OIDC = map[string]string{}
+			s.Mail = map[string]string{}
+			s.LogPath = "/config/logs"
+			return s, nil
+		}
+		return s, err
+	}
+	if len(storage) > 0 {
+		_ = json.Unmarshal(storage, &s.Storage)
+	} else {
+		s.Storage = map[string]string{}
+	}
+	if len(oidc) > 0 {
+		_ = json.Unmarshal(oidc, &s.OIDC)
+	} else {
+		s.OIDC = map[string]string{}
+	}
+	if len(mail) > 0 {
+		_ = json.Unmarshal(mail, &s.Mail)
+	} else {
+		s.Mail = map[string]string{}
+	}
+	if lt != nil {
+		s.LastTest = lt.Format(time.RFC3339)
+	}
+	return s, nil
+}
+
+// GetSettings returns the current configuration from the database.
+func GetSettings(db DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		s, err := loadSettings(c.Request.Context(), db)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, s)
+	}
 }
 
 // SaveStorageSettings stores storage configuration.
-func SaveStorageSettings(c *gin.Context) {
-	var data map[string]string
-	if err := c.ShouldBindJSON(&data); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
+func SaveStorageSettings(db DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var data map[string]string
+		if err := c.ShouldBindJSON(&data); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		b, _ := json.Marshal(data)
+		if _, err := db.Exec(c.Request.Context(), "update settings set storage=$1 where id=1", b); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
 	}
-	mu.Lock()
-	cfgStore.Storage = data
-	mu.Unlock()
-	c.JSON(http.StatusOK, gin.H{"ok": true})
 }
 
 // SaveOIDCSettings stores OIDC configuration.
-func SaveOIDCSettings(c *gin.Context) {
-	var data map[string]string
-	if err := c.ShouldBindJSON(&data); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
+func SaveOIDCSettings(db DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var data map[string]string
+		if err := c.ShouldBindJSON(&data); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		b, _ := json.Marshal(data)
+		if _, err := db.Exec(c.Request.Context(), "update settings set oidc=$1 where id=1", b); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
 	}
-	mu.Lock()
-	cfgStore.OIDC = data
-	mu.Unlock()
-	c.JSON(http.StatusOK, gin.H{"ok": true})
 }
 
 // SaveMailSettings stores mail configuration.
-func SaveMailSettings(c *gin.Context) {
-	var data map[string]string
-	if err := c.ShouldBindJSON(&data); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
+func SaveMailSettings(db DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var data map[string]string
+		if err := c.ShouldBindJSON(&data); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		b, _ := json.Marshal(data)
+		if _, err := db.Exec(c.Request.Context(), "update settings set mail=$1 where id=1", b); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
 	}
-	mu.Lock()
-	cfgStore.Mail = data
-	mu.Unlock()
-	c.JSON(http.StatusOK, gin.H{"ok": true})
 }
 
 // TestConnection records a test run and returns log path and last result.
-func TestConnection(c *gin.Context) {
-	mu.Lock()
-	cfgStore.LastTest = time.Now().Format(time.RFC3339)
-	resp := gin.H{"ok": true, "log_path": cfgStore.LogPath, "last_test": cfgStore.LastTest}
-	mu.Unlock()
-	c.JSON(http.StatusOK, resp)
+func TestConnection(db DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		now := time.Now()
+		if _, err := db.Exec(c.Request.Context(), "update settings set last_test=$1 where id=1", now); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		s, err := loadSettings(c.Request.Context(), db)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true, "log_path": s.LogPath, "last_test": s.LastTest})
+	}
 }

--- a/cmd/api/handlers/settings_test.go
+++ b/cmd/api/handlers/settings_test.go
@@ -2,21 +2,108 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
+
+type fakeRow struct {
+	scan func(dest ...any) error
+}
+
+func (r *fakeRow) Scan(dest ...any) error {
+	if r.scan != nil {
+		return r.scan(dest...)
+	}
+	return nil
+}
+
+type fakeDB struct {
+	s Settings
+}
+
+func (db *fakeDB) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	lower := strings.ToLower(strings.TrimSpace(sql))
+	if strings.HasPrefix(lower, "select") {
+		return &fakeRow{scan: func(dest ...any) error {
+			b, _ := json.Marshal(db.s.Storage)
+			if p, ok := dest[0].(*[]byte); ok {
+				*p = b
+			}
+			b, _ = json.Marshal(db.s.OIDC)
+			if p, ok := dest[1].(*[]byte); ok {
+				*p = b
+			}
+			b, _ = json.Marshal(db.s.Mail)
+			if p, ok := dest[2].(*[]byte); ok {
+				*p = b
+			}
+			if p, ok := dest[3].(*string); ok {
+				*p = db.s.LogPath
+			}
+			if p, ok := dest[4].(**time.Time); ok {
+				if db.s.LastTest != "" {
+					t, _ := time.Parse(time.RFC3339, db.s.LastTest)
+					*p = &t
+				} else {
+					*p = nil
+				}
+			}
+			return nil
+		}}
+	}
+	return &fakeRow{}
+}
+
+func (db *fakeDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	s := strings.ToLower(sql)
+	switch {
+	case strings.Contains(s, "insert into settings"):
+		if len(args) > 0 {
+			if lp, ok := args[len(args)-1].(string); ok && lp != "" {
+				db.s.LogPath = lp
+			}
+		}
+	case strings.Contains(s, "update settings set storage"):
+		if b, ok := args[0].([]byte); ok {
+			_ = json.Unmarshal(b, &db.s.Storage)
+		}
+	case strings.Contains(s, "update settings set oidc"):
+		if b, ok := args[0].([]byte); ok {
+			_ = json.Unmarshal(b, &db.s.OIDC)
+		}
+	case strings.Contains(s, "update settings set mail"):
+		if b, ok := args[0].([]byte); ok {
+			_ = json.Unmarshal(b, &db.s.Mail)
+		}
+	case strings.Contains(s, "update settings set last_test"):
+		if t, ok := args[0].(time.Time); ok {
+			db.s.LastTest = t.Format(time.RFC3339)
+		}
+	case strings.Contains(s, "update settings set log_path"):
+		if lp, ok := args[0].(string); ok {
+			db.s.LogPath = lp
+		}
+	}
+	return pgconn.CommandTag{}, nil
+}
 
 func TestSettingsHandlers(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	InitSettings("/tmp/logs")
+	db := &fakeDB{s: Settings{Storage: map[string]string{}, OIDC: map[string]string{}, Mail: map[string]string{}}}
+	InitSettings(context.Background(), db, "/tmp/logs")
 	r := gin.New()
-	r.GET("/settings", GetSettings)
-	r.POST("/settings/storage", SaveStorageSettings)
-	r.POST("/test-connection", TestConnection)
+	r.GET("/settings", GetSettings(db))
+	r.POST("/settings/storage", SaveStorageSettings(db))
+	r.POST("/test-connection", TestConnection(db))
 
 	// initial log path
 	w := httptest.NewRecorder()

--- a/cmd/api/handlers/settings_test.go
+++ b/cmd/api/handlers/settings_test.go
@@ -73,16 +73,25 @@ func (db *fakeDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.Com
 			}
 		}
 	case strings.Contains(s, "update settings set storage"):
-		if b, ok := args[0].([]byte); ok {
-			_ = json.Unmarshal(b, &db.s.Storage)
+		switch v := args[0].(type) {
+		case string:
+			_ = json.Unmarshal([]byte(v), &db.s.Storage)
+		case []byte:
+			_ = json.Unmarshal(v, &db.s.Storage)
 		}
 	case strings.Contains(s, "update settings set oidc"):
-		if b, ok := args[0].([]byte); ok {
-			_ = json.Unmarshal(b, &db.s.OIDC)
+		switch v := args[0].(type) {
+		case string:
+			_ = json.Unmarshal([]byte(v), &db.s.OIDC)
+		case []byte:
+			_ = json.Unmarshal(v, &db.s.OIDC)
 		}
 	case strings.Contains(s, "update settings set mail"):
-		if b, ok := args[0].([]byte); ok {
-			_ = json.Unmarshal(b, &db.s.Mail)
+		switch v := args[0].(type) {
+		case string:
+			_ = json.Unmarshal([]byte(v), &db.s.Mail)
+		case []byte:
+			_ = json.Unmarshal(v, &db.s.Mail)
 		}
 	case strings.Contains(s, "update settings set last_test"):
 		if t, ok := args[0].(time.Time); ok {

--- a/cmd/api/migrations/0006_settings.sql
+++ b/cmd/api/migrations/0006_settings.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+create table if not exists settings (
+    id smallint primary key default 1,
+    storage jsonb not null default '{}'::jsonb,
+    oidc jsonb not null default '{}'::jsonb,
+    mail jsonb not null default '{}'::jsonb,
+    log_path text not null default '/config/logs',
+    last_test timestamptz
+);
+insert into settings (id) values (1) on conflict do nothing;
+
+-- +goose Down
+drop table if exists settings;


### PR DESCRIPTION
## Summary
- add settings table migration
- load and save settings from database instead of global store
- test settings persistence with fake DB

## Testing
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b78547b7988322a0629739d91b91f5