### PR TITLE
api: persist settings in database

### DIFF
--- a/cmd/api/handlers/settings.go
+++ b/cmd/api/handlers/settings.go
@@ -95,7 +95,7 @@ func SaveStorageSettings(db DB) gin.HandlerFunc {
 			return
 		}
 		b, _ := json.Marshal(data)
-		if _, err := db.Exec(c.Request.Context(), "update settings set storage=$1 where id=1", b); err != nil {
+		if _, err := db.Exec(c.Request.Context(), "update settings set storage=$1::jsonb where id=1", string(b)); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
@@ -112,7 +112,7 @@ func SaveOIDCSettings(db DB) gin.HandlerFunc {
 			return
 		}
 		b, _ := json.Marshal(data)
-		if _, err := db.Exec(c.Request.Context(), "update settings set oidc=$1 where id=1", b); err != nil {
+		if _, err := db.Exec(c.Request.Context(), "update settings set oidc=$1::jsonb where id=1", string(b)); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
@@ -129,7 +129,7 @@ func SaveMailSettings(db DB) gin.HandlerFunc {
 			return
 		}
 		b, _ := json.Marshal(data)
-		if _, err := db.Exec(c.Request.Context(), "update settings set mail=$1 where id=1", b); err != nil {
+		if _, err := db.Exec(c.Request.Context(), "update settings set mail=$1::jsonb where id=1", string(b)); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}

--- a/cmd/api/handlers/settings_test.go
+++ b/cmd/api/handlers/settings_test.go
@@ -73,16 +73,25 @@ func (db *fakeDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.Com
 			}
 		}
 	case strings.Contains(s, "update settings set storage"):
-		if b, ok := args[0].([]byte); ok {
-			_ = json.Unmarshal(b, &db.s.Storage)
+		switch v := args[0].(type) {
+		case string:
+			_ = json.Unmarshal([]byte(v), &db.s.Storage)
+		case []byte:
+			_ = json.Unmarshal(v, &db.s.Storage)
 		}
 	case strings.Contains(s, "update settings set oidc"):
-		if b, ok := args[0].([]byte); ok {
-			_ = json.Unmarshal(b, &db.s.OIDC)
+		switch v := args[0].(type) {
+		case string:
+			_ = json.Unmarshal([]byte(v), &db.s.OIDC)
+		case []byte:
+			_ = json.Unmarshal(v, &db.s.OIDC)
 		}
 	case strings.Contains(s, "update settings set mail"):
-		if b, ok := args[0].([]byte); ok {
-			_ = json.Unmarshal(b, &db.s.Mail)
+		switch v := args[0].(type) {
+		case string:
+			_ = json.Unmarshal([]byte(v), &db.s.Mail)
+		case []byte:
+			_ = json.Unmarshal(v, &db.s.Mail)
 		}
 	case strings.Contains(s, "update settings set last_test"):
 		if t, ok := args[0].(time.Time); ok {


### PR DESCRIPTION
## Summary
- add settings table migration
- load and save settings from database instead of global store
- test settings persistence with fake DB
- cast settings JSON updates to jsonb

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b7881a87bc8322ac6b1099498366ee