### PR TITLE
api: modularize handlers

### DIFF
--- a/cmd/api/auth/auth_middleware_test.go
+++ b/cmd/api/auth/auth_middleware_test.go
@@ -1,0 +1,52 @@
+package auth_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+)
+
+func TestMiddlewarePopulatesUserFromClaims(t *testing.T) {
+	cfg := apppkg.Config{Env: "test", OIDCGroupClaim: "roles"}
+	key := []byte("secret")
+	keyf := func(t *jwt.Token) (any, error) { return key, nil }
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub":   "user-123",
+		"email": "user@example.com",
+		"name":  "User Name",
+		"roles": []string{"agent", "manager"},
+	})
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	a := apppkg.NewApp(cfg, nil, keyf, nil, nil)
+	a.R.GET("/me", authpkg.Middleware(a), authpkg.Me)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/me", nil)
+	req.Header.Set("Authorization", "Bearer "+signed)
+	a.R.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var u authpkg.AuthUser
+	if err := json.Unmarshal(rr.Body.Bytes(), &u); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if u.Email != "user@example.com" || u.DisplayName != "User Name" {
+		t.Fatalf("unexpected user: %+v", u)
+	}
+	if len(u.Roles) != 2 || u.Roles[0] != "agent" || u.Roles[1] != "manager" {
+		t.Fatalf("roles not populated: %+v", u.Roles)
+	}
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,7 +1,20 @@
 package main
 
 import (
+	"context"
+	"io"
+	"os"
+	"time"
+
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
 	attachmentspkg "github.com/mark3748/helpdesk-go/cmd/api/attachments"
@@ -15,7 +28,74 @@ import (
 
 func main() {
 	cfg := apppkg.GetConfig()
-	a := apppkg.NewApp(cfg, nil, nil, nil, nil)
+	writer := io.Writer(os.Stdout)
+	if cfg.Env == "dev" {
+		writer = zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+	}
+	log.Logger = zerolog.New(writer).With().Timestamp().Logger()
+
+	ctx := context.Background()
+
+	db, err := pgxpool.New(ctx, cfg.DatabaseURL)
+	if err != nil {
+		log.Fatal().Err(err).Msg("db connect")
+	}
+	defer db.Close()
+
+	var keyf jwt.Keyfunc
+	if cfg.JWKSURL != "" {
+		set, err := jwk.Fetch(ctx, cfg.JWKSURL)
+		if err != nil {
+			log.Fatal().Err(err).Msg("jwks fetch")
+		}
+		keyf = func(tk *jwt.Token) (any, error) {
+			kid, _ := tk.Header["kid"].(string)
+			if kid != "" {
+				if key, ok := set.LookupKeyID(kid); ok {
+					var pub any
+					if err := key.Raw(&pub); err != nil {
+						return nil, err
+					}
+					return pub, nil
+				}
+			}
+			it := set.Iterate(ctx)
+			if it.Next(ctx) {
+				pair := it.Pair()
+				if key, ok := pair.Value.(jwk.Key); ok {
+					var pub any
+					if err := key.Raw(&pub); err != nil {
+						return nil, err
+					}
+					return pub, nil
+				}
+			}
+			return nil, jwt.ErrTokenSignatureInvalid
+		}
+	}
+
+	var store apppkg.ObjectStore
+	if cfg.FileStorePath != "" {
+		store = &apppkg.FsObjectStore{Base: cfg.FileStorePath}
+	} else if cfg.MinIOEndpoint != "" {
+		mc, err := minio.New(cfg.MinIOEndpoint, &minio.Options{
+			Creds:  credentials.NewStaticV4(cfg.MinIOAccess, cfg.MinIOSecret, ""),
+			Secure: cfg.MinIOUseSSL,
+		})
+		if err != nil {
+			log.Error().Err(err).Msg("minio init")
+		} else {
+			store = mc
+		}
+	}
+
+	rdb := redis.NewClient(&redis.Options{Addr: cfg.RedisAddr})
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		log.Error().Err(err).Msg("redis ping failed")
+	}
+	defer rdb.Close()
+
+	a := apppkg.NewApp(cfg, db, keyf, store, rdb)
 
 	a.R.GET("/healthz", func(c *gin.Context) { c.JSON(200, gin.H{"ok": true}) })
 

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -148,4 +148,15 @@ func TestCreateTicketValidationErrors(t *testing.T) {
 			t.Fatalf("expected custom_json error, got %v", resp.Errors)
 		}
 	})
+
+	t.Run("null custom_json", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		body := `{"title":"abc","requester_id":"00000000-0000-0000-0000-000000000000","priority":1,"custom_json":null}`
+		req := httptest.NewRequest(http.MethodPost, "/tickets", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		a.R.ServeHTTP(rr, req)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d", rr.Code)
+		}
+	})
 }

--- a/cmd/api/tickets/tickets.go
+++ b/cmd/api/tickets/tickets.go
@@ -52,7 +52,7 @@ func Create(a *app.App) gin.HandlerFunc {
 		}
 		if len(in.CustomJSON) > 0 {
 			var tmp interface{}
-			if err := json.Unmarshal(in.CustomJSON, &tmp); err != nil || reflect.ValueOf(tmp).Kind() != reflect.Map {
+			if err := json.Unmarshal(in.CustomJSON, &tmp); err != nil || (tmp != nil && reflect.ValueOf(tmp).Kind() != reflect.Map) {
 				c.JSON(http.StatusBadRequest, gin.H{"errors": map[string]string{"custom_json": "must be object"}})
 				return
 			}


### PR DESCRIPTION
## Summary
- wire dependencies before starting API server
- populate AuthUser from JWT claims
- guard against nil ticket custom_json payloads

## Testing
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b79111e8e883228b250924fdafa2dc