### PR TITLE
api: add request ID and rate limiter middleware

### DIFF
--- a/cmd/api/app/app.go
+++ b/cmd/api/app/app.go
@@ -151,11 +151,10 @@ func NewApp(cfg Config, db DB, keyf jwt.Keyfunc, store ObjectStore, q *redis.Cli
 	a := &App{Cfg: cfg, DB: db, R: gin.New(), Keyf: keyf, M: store, Q: q}
 	a.R.Use(gin.Recovery())
 	a.R.Use(RequestID())
-	rl := rate.NewLimiter(rate.Inf, 0)
-	if cfg.RateLimitRPS > 0 {
-		rl = rate.NewLimiter(rate.Limit(cfg.RateLimitRPS), cfg.RateLimitBurst)
+	if cfg.RateLimitRPS > 0 && cfg.RateLimitBurst > 0 {
+		rl := rate.NewLimiter(rate.Limit(cfg.RateLimitRPS), cfg.RateLimitBurst)
+		a.R.Use(RateLimit(rl))
 	}
-	a.R.Use(RateLimit(rl))
 	a.R.Use(Logger())
 	return a
 }

--- a/cmd/api/app/app_test.go
+++ b/cmd/api/app/app_test.go
@@ -47,3 +47,23 @@ func TestRateLimit(t *testing.T) {
 		t.Fatalf("expected 429, got %d", rr.Code)
 	}
 }
+
+// Test that the rate limiter is disabled when no configuration is provided.
+func TestRateLimitDisabledByDefault(t *testing.T) {
+	cfg := Config{Env: "test"}
+	a := NewApp(cfg, nil, nil, nil, nil)
+	a.R.GET("/", func(c *gin.Context) { c.JSON(200, gin.H{"ok": true}) })
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- skip rate limiter middleware unless both RPS and burst are configured
- add test ensuring default config leaves requests unlimited

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./cmd/... ./internal/...` *(hangs while downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b795788f90832291ae025e78731eea