### PR TITLE
worker: sanitize attachment filenames

### DIFF
--- a/cmd/worker/email_security_test.go
+++ b/cmd/worker/email_security_test.go
@@ -70,6 +70,43 @@ func TestSanitizeEmailBody(t *testing.T) {
 	}
 }
 
+func TestSanitizeAttachmentName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple filename",
+			input:    "file.txt",
+			expected: "file.txt",
+		},
+		{
+			name:     "path traversal",
+			input:    "../../../../etc/passwd",
+			expected: "passwd",
+		},
+		{
+			name:     "windows traversal",
+			input:    "..\\..\\evil.txt",
+			expected: "evil.txt",
+		},
+		{
+			name:     "empty",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeAttachmentName(tt.input); got != tt.expected {
+				t.Errorf("sanitizeAttachmentName(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestValidateEmailAddress(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -238,4 +275,3 @@ func TestSendEmailSecurityValidation(t *testing.T) {
 		t.Error("Email validation should have passed for clean email address")
 	}
 }
-

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/smtp"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -137,6 +138,20 @@ func sanitizeAndValidateEmail(email string) (string, error) {
 // sanitizeEmailBody removes potentially harmful HTML or scripts from an email body
 func sanitizeEmailBody(body []byte) string {
 	return string(htmlPolicy.SanitizeBytes(body))
+}
+
+// sanitizeAttachmentName strips path components to prevent filesystem traversal
+func sanitizeAttachmentName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	name = strings.ReplaceAll(name, "\\", "/")
+	name = path.Base(name)
+	if name == "." || name == ".." {
+		return ""
+	}
+	return name
 }
 
 func sendEmail(c Config, j EmailJob) error {


### PR DESCRIPTION
## Summary
- prevent path traversal by stripping path components from attachment names
- cover attachment filename sanitization with unit tests

## Testing
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b79929e388832295fb74b2e215f49e