### PR TITLE
Add API and worker tests with coverage threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,8 @@ jobs:
         run: |
           git diff --exit-code go.mod go.sum
       - name: Run full test suite
-        env:
-          TEST_BYPASS_AUTH: true
         run: |
-          go test -v -cover ./...
+          TEST_BYPASS_AUTH=true go test -cover ./...
       - name: Build API image
         run: docker build -f Dockerfile.api -t helpdesk-api .
       - name: Build worker image

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ See `docs/api.md` for detailed status codes, request/response bodies, and models
 - Unit tests can bypass JWT validation by setting `TEST_BYPASS_AUTH=true`. This injects a synthetic user with the `agent` role so auth-protected routes can be exercised without a JWKS.
 - Handlers depend on database and object storage interfaces, enabling fakes in tests without external services.
 - Run all tests from repo root: `go test ./...`
+- The project targets **≥70%** test coverage across packages; pull requests should not drop below this threshold.
 
 ## Continuous Integration
 

--- a/cmd/api/attachments/attachments_test.go
+++ b/cmd/api/attachments/attachments_test.go
@@ -1,0 +1,44 @@
+package attachments
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+)
+
+func TestAttachmentHandlers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := apppkg.Config{Env: "test", TestBypassAuth: true}
+	a := apppkg.NewApp(cfg, nil, nil, nil, nil)
+	a.R.GET("/tickets/:id/attachments", authpkg.Middleware(a), List(a))
+	a.R.POST("/tickets/:id/attachments", authpkg.Middleware(a), Upload(a))
+	a.R.GET("/tickets/:id/attachments/:att", authpkg.Middleware(a), Get(a))
+	a.R.DELETE("/tickets/:id/attachments/:att", authpkg.Middleware(a), Delete(a))
+
+	tests := []struct {
+		name   string
+		method string
+		url    string
+		want   int
+	}{
+		{"list", http.MethodGet, "/tickets/1/attachments", http.StatusOK},
+		{"upload", http.MethodPost, "/tickets/1/attachments", http.StatusCreated},
+		{"get", http.MethodGet, "/tickets/1/attachments/1", http.StatusOK},
+		{"delete", http.MethodDelete, "/tickets/1/attachments/1", http.StatusOK},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(tt.method, tt.url, nil)
+			a.R.ServeHTTP(rr, req)
+			if rr.Code != tt.want {
+				t.Fatalf("expected %d, got %d", tt.want, rr.Code)
+			}
+		})
+	}
+}

--- a/cmd/api/metrics/metrics_test.go
+++ b/cmd/api/metrics/metrics_test.go
@@ -1,0 +1,40 @@
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+)
+
+func TestMetricsHandlers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := apppkg.Config{Env: "test", TestBypassAuth: true}
+	a := apppkg.NewApp(cfg, nil, nil, nil, nil)
+	a.R.GET("/metrics/sla", authpkg.Middleware(a), SLA(a))
+	a.R.GET("/metrics/resolution", authpkg.Middleware(a), Resolution(a))
+	a.R.GET("/metrics/ticket_volume", authpkg.Middleware(a), TicketVolume(a))
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"sla", "/metrics/sla"},
+		{"resolution", "/metrics/resolution"},
+		{"volume", "/metrics/ticket_volume"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			a.R.ServeHTTP(rr, req)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rr.Code)
+			}
+		})
+	}
+}

--- a/cmd/api/tickets/tickets_test.go
+++ b/cmd/api/tickets/tickets_test.go
@@ -1,0 +1,56 @@
+package tickets
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+)
+
+func TestTicketHandlers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := apppkg.Config{Env: "test", TestBypassAuth: true}
+	a := apppkg.NewApp(cfg, nil, nil, nil, nil)
+	a.R.POST("/tickets", authpkg.Middleware(a), Create(a))
+	a.R.GET("/tickets", authpkg.Middleware(a), List(a))
+	a.R.GET("/tickets/:id", authpkg.Middleware(a), Get(a))
+	a.R.PUT("/tickets/:id", authpkg.Middleware(a), Update(a))
+
+	tests := []struct {
+		name   string
+		method string
+		url    string
+		body   string
+		want   int
+	}{
+		{"list", http.MethodGet, "/tickets", "", http.StatusOK},
+		{"create", http.MethodPost, "/tickets", `{"title":"abc","requester_id":"00000000-0000-0000-0000-000000000000","priority":1}`, http.StatusCreated},
+		{"get", http.MethodGet, "/tickets/1", "", http.StatusOK},
+		{"update", http.MethodPut, "/tickets/1", `{}`, http.StatusOK},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(tt.method, tt.url, strings.NewReader(tt.body))
+			if tt.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			a.R.ServeHTTP(rr, req)
+			if rr.Code != tt.want {
+				t.Fatalf("expected %d, got %d", tt.want, rr.Code)
+			}
+			if tt.name == "create" {
+				var tk Ticket
+				if err := json.Unmarshal(rr.Body.Bytes(), &tk); err != nil || tk.Title != "abc" {
+					t.Fatalf("unexpected ticket: %v %v", tk, err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/api/watchers/watchers_test.go
+++ b/cmd/api/watchers/watchers_test.go
@@ -1,0 +1,42 @@
+package watchers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+)
+
+func TestWatcherHandlers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := apppkg.Config{Env: "test", TestBypassAuth: true}
+	a := apppkg.NewApp(cfg, nil, nil, nil, nil)
+	a.R.GET("/tickets/:id/watchers", authpkg.Middleware(a), List(a))
+	a.R.POST("/tickets/:id/watchers", authpkg.Middleware(a), Add(a))
+	a.R.DELETE("/tickets/:id/watchers/:uid", authpkg.Middleware(a), Remove(a))
+
+	tests := []struct {
+		name   string
+		method string
+		url    string
+		want   int
+	}{
+		{"list", http.MethodGet, "/tickets/1/watchers", http.StatusOK},
+		{"add", http.MethodPost, "/tickets/1/watchers", http.StatusCreated},
+		{"remove", http.MethodDelete, "/tickets/1/watchers/1", http.StatusOK},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(tt.method, tt.url, nil)
+			a.R.ServeHTTP(rr, req)
+			if rr.Code != tt.want {
+				t.Fatalf("expected %d, got %d", tt.want, rr.Code)
+			}
+		})
+	}
+}

--- a/cmd/worker/imap_test.go
+++ b/cmd/worker/imap_test.go
@@ -156,7 +156,17 @@ func (f *fakeIMAPClient) Search(criteria *imap.SearchCriteria) ([]uint32, error)
 	return []uint32{1}, nil
 }
 func (f *fakeIMAPClient) Fetch(seqset *imap.SeqSet, items []imap.FetchItem, ch chan *imap.Message) error {
-	section := &imap.BodySectionName{}
+	// Use the same body section requested by pollIMAP so msg.GetBody can find it.
+	var section *imap.BodySectionName
+	for _, it := range items {
+		if s, err := imap.ParseBodySectionName(it); err == nil {
+			section = s
+			break
+		}
+	}
+	if section == nil {
+		section = &imap.BodySectionName{}
+	}
 	msg := &imap.Message{SeqNum: 1, Body: map[*imap.BodySectionName]imap.Literal{section: &bytesLiteral{data: f.raw}}}
 	ch <- msg
 	close(ch)

--- a/cmd/worker/imap_test.go
+++ b/cmd/worker/imap_test.go
@@ -6,9 +6,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/emersion/go-imap"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/minio/minio-go/v7"
+	"github.com/redis/go-redis/v9"
+
+	app "github.com/mark3748/helpdesk-go/cmd/api/app"
 )
 
 // fakeStore implements app.ObjectStore for tests.
@@ -120,5 +124,72 @@ func TestProcessIMAPMessage_Duplicate(t *testing.T) {
 	}
 	if len(store.objects) != 0 {
 		t.Fatalf("expected no stored objects, got %d", len(store.objects))
+	}
+}
+
+type bytesLiteral struct {
+	data []byte
+	idx  int
+}
+
+func (l *bytesLiteral) Read(p []byte) (int, error) {
+	if l.idx >= len(l.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, l.data[l.idx:])
+	l.idx += n
+	return n, nil
+}
+
+func (l *bytesLiteral) Len() int { return len(l.data) - l.idx }
+
+type fakeIMAPClient struct {
+	raw    []byte
+	stored bool
+}
+
+func (f *fakeIMAPClient) Login(username, password string) error { return nil }
+func (f *fakeIMAPClient) Select(mailbox string, readOnly bool) (*imap.MailboxStatus, error) {
+	return &imap.MailboxStatus{Messages: 1}, nil
+}
+func (f *fakeIMAPClient) Search(criteria *imap.SearchCriteria) ([]uint32, error) {
+	return []uint32{1}, nil
+}
+func (f *fakeIMAPClient) Fetch(seqset *imap.SeqSet, items []imap.FetchItem, ch chan *imap.Message) error {
+	section := &imap.BodySectionName{}
+	msg := &imap.Message{SeqNum: 1, Body: map[*imap.BodySectionName]imap.Literal{section: &bytesLiteral{data: f.raw}}}
+	ch <- msg
+	close(ch)
+	return nil
+}
+func (f *fakeIMAPClient) Store(seqset *imap.SeqSet, item imap.StoreItem, value interface{}, ch chan *imap.Message) error {
+	f.stored = true
+	return nil
+}
+func (f *fakeIMAPClient) Logout() error { return nil }
+
+func TestPollIMAP(t *testing.T) {
+	raw := []byte(sampleEmail)
+	cli := &fakeIMAPClient{raw: raw}
+	dialOrig := dialIMAP
+	dialIMAP = func(addr string) (imapClient, error) { return cli, nil }
+	defer func() { dialIMAP = dialOrig }()
+
+	var processed []byte
+	procOrig := processIMAP
+	processIMAP = func(ctx context.Context, c Config, db app.DB, store app.ObjectStore, rdb *redis.Client, r []byte) error {
+		processed = r
+		return nil
+	}
+	defer func() { processIMAP = procOrig }()
+
+	if err := pollIMAP(context.Background(), Config{IMAPHost: "host", IMAPUser: "u", IMAPPass: "p", IMAPFolder: "INBOX"}, nil, nil, nil); err != nil {
+		t.Fatalf("pollIMAP: %v", err)
+	}
+	if string(processed) != string(raw) {
+		t.Fatalf("processIMAP called with wrong data")
+	}
+	if !cli.stored {
+		t.Fatalf("expected store called")
 	}
 }

--- a/cmd/worker/worker_test.go
+++ b/cmd/worker/worker_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/smtp"
+	"strings"
+	"testing"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestSendEmail(t *testing.T) {
+	var captured struct {
+		addr string
+		from string
+		to   []string
+		msg  string
+	}
+	smtpSendMail = func(addr string, _ smtp.Auth, from string, to []string, msg []byte) error {
+		captured = struct {
+			addr string
+			from string
+			to   []string
+			msg  string
+		}{addr, from, to, string(msg)}
+		return nil
+	}
+	defer func() { smtpSendMail = smtp.SendMail }()
+
+	c := Config{SMTPHost: "smtp", SMTPPort: "25", SMTPFrom: "from@example.com"}
+	j := EmailJob{To: "to@example.com", Template: "ticket_created", Data: struct{ Number int }{1}}
+	if err := sendEmail(c, j); err != nil {
+		t.Fatalf("sendEmail: %v", err)
+	}
+	if captured.addr != "smtp:25" || captured.from != "from@example.com" || captured.to[0] != "to@example.com" {
+		t.Fatalf("unexpected send params: %+v", captured)
+	}
+	if !strings.Contains(captured.msg, "Ticket created") {
+		t.Fatalf("unexpected message: %s", captured.msg)
+	}
+}
+
+func TestProcessQueueJob(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	defer mr.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	c := Config{SMTPFrom: "from@example.com"}
+	job := Job{Type: "send_email", Data: json.RawMessage(`{"to":"t@example.com","template":"ticket_created","data":{"Number":1}}`)}
+	payload, _ := json.Marshal(job)
+	if err := rdb.LPush(context.Background(), "jobs", payload).Err(); err != nil {
+		t.Fatalf("lpush: %v", err)
+	}
+	called := false
+	send := func(c Config, j EmailJob) error {
+		called = true
+		return nil
+	}
+	if err := processQueueJob(context.Background(), c, rdb, send); err != nil {
+		t.Fatalf("processQueueJob: %v", err)
+	}
+	if !called {
+		t.Fatalf("sendEmail not called")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.24.6
 
 require (
+	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/emersion/go-imap v1.2.1
 	github.com/emersion/go-message v0.18.0
 	github.com/gin-gonic/gin v1.10.1
@@ -68,6 +69,7 @@ require (
 	github.com/tinylib/msgp v1.3.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/net v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
+github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -156,6 +158,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/arch v0.8.0 h1:3wRIsP3pM4yUptoR96otTUOXI367OS0+c9eeRi9doIc=
 golang.org/x/arch v0.8.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=


### PR DESCRIPTION
## Summary
- add table-driven tests for ticket CRUD, attachments, watchers and metrics
- exercise worker email sending, queue handling and IMAP polling via fakes
- document 70% coverage target and run tests with TEST_BYPASS_AUTH

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b79b77f6fc8322b840841084bdf072