### PR TITLE
api: add requester handlers and inline ticket creation

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -19,21 +19,22 @@ import (
 	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
 	attachmentspkg "github.com/mark3748/helpdesk-go/cmd/api/attachments"
 	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
-	handlers "github.com/mark3748/helpdesk-go/cmd/api/handlers"
 	commentspkg "github.com/mark3748/helpdesk-go/cmd/api/comments"
-	exportspkg "github.com/mark3748/helpdesk-go/cmd/api/exports"
-	metricspkg "github.com/mark3748/helpdesk-go/cmd/api/metrics"
 	eventspkg "github.com/mark3748/helpdesk-go/cmd/api/events"
+	exportspkg "github.com/mark3748/helpdesk-go/cmd/api/exports"
+	handlers "github.com/mark3748/helpdesk-go/cmd/api/handlers"
+	metricspkg "github.com/mark3748/helpdesk-go/cmd/api/metrics"
 	migratepkg "github.com/mark3748/helpdesk-go/cmd/api/migrations"
+	requesterspkg "github.com/mark3748/helpdesk-go/cmd/api/requesters"
 	rolespkg "github.com/mark3748/helpdesk-go/cmd/api/roles"
-	userspkg "github.com/mark3748/helpdesk-go/cmd/api/users"
 	ticketspkg "github.com/mark3748/helpdesk-go/cmd/api/tickets"
+	userspkg "github.com/mark3748/helpdesk-go/cmd/api/users"
 	watcherspkg "github.com/mark3748/helpdesk-go/cmd/api/watchers"
 )
 
 func main() {
-    cfg := apppkg.GetConfig()
-    writer := io.Writer(os.Stdout)
+	cfg := apppkg.GetConfig()
+	writer := io.Writer(os.Stdout)
 	if cfg.Env == "dev" {
 		writer = zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
 	}
@@ -106,34 +107,38 @@ func main() {
 	}
 	defer rdb.Close()
 
-    a := apppkg.NewApp(cfg, db, keyf, store, rdb)
+	a := apppkg.NewApp(cfg, db, keyf, store, rdb)
 
-    // Serve OpenAPI spec and Swagger UI
-    a.R.GET("/openapi.yaml", func(c *gin.Context) {
-        // Resolve spec path: env override, repo-local, then image path
-        candidates := []string{}
-        if cfg.OpenAPISpecPath != "" { candidates = append(candidates, cfg.OpenAPISpecPath) }
-        candidates = append(candidates, "docs/openapi.yaml", "/opt/helpdesk/docs/openapi.yaml")
-        var content []byte
-        for _, p := range candidates {
-            if p == "" { continue }
-            if b, err := os.ReadFile(p); err == nil {
-                content = b
-                break
-            }
-        }
-        if len(content) == 0 {
-            c.AbortWithStatusJSON(404, gin.H{"error": "openapi not found"})
-            return
-        }
-        c.Data(200, "application/yaml", content)
-    })
-    // Conditionally serve local swagger assets if present; fall back to CDN via /docs page
-    if _, err := os.Stat("/opt/helpdesk/swagger"); err == nil {
-        a.R.Static("/swagger", "/opt/helpdesk/swagger")
-    }
-    a.R.GET("/docs", func(c *gin.Context) {
-        html := `<!doctype html>
+	// Serve OpenAPI spec and Swagger UI
+	a.R.GET("/openapi.yaml", func(c *gin.Context) {
+		// Resolve spec path: env override, repo-local, then image path
+		candidates := []string{}
+		if cfg.OpenAPISpecPath != "" {
+			candidates = append(candidates, cfg.OpenAPISpecPath)
+		}
+		candidates = append(candidates, "docs/openapi.yaml", "/opt/helpdesk/docs/openapi.yaml")
+		var content []byte
+		for _, p := range candidates {
+			if p == "" {
+				continue
+			}
+			if b, err := os.ReadFile(p); err == nil {
+				content = b
+				break
+			}
+		}
+		if len(content) == 0 {
+			c.AbortWithStatusJSON(404, gin.H{"error": "openapi not found"})
+			return
+		}
+		c.Data(200, "application/yaml", content)
+	})
+	// Conditionally serve local swagger assets if present; fall back to CDN via /docs page
+	if _, err := os.Stat("/opt/helpdesk/swagger"); err == nil {
+		a.R.Static("/swagger", "/opt/helpdesk/swagger")
+	}
+	a.R.GET("/docs", func(c *gin.Context) {
+		html := `<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -161,36 +166,39 @@ func main() {
     </script>
   </body>
 </html>`
-        c.Data(200, "text/html; charset=utf-8", []byte(html))
-    })
+		c.Data(200, "text/html; charset=utf-8", []byte(html))
+	})
 
-    // Public and authenticated API endpoints are mounted under /api
-    api := a.R.Group("/api")
-    api.GET("/healthz", func(c *gin.Context) { c.JSON(200, gin.H{"ok": true}) })
-    // Basic auth endpoints
-    api.POST("/login", authpkg.Login(a))
-    api.POST("/logout", authpkg.Logout())
+	// Public and authenticated API endpoints are mounted under /api
+	api := a.R.Group("/api")
+	api.GET("/healthz", func(c *gin.Context) { c.JSON(200, gin.H{"ok": true}) })
+	// Basic auth endpoints
+	api.POST("/login", authpkg.Login(a))
+	api.POST("/logout", authpkg.Logout())
 
-    // Public SSE (requires auth cookie; still under auth group)
-    // NOTE: Expose under authenticated group to include auth middleware
-    // so the cookie is validated before streaming.
-    // We'll attach it below under auth.
+	// Public SSE (requires auth cookie; still under auth group)
+	// NOTE: Expose under authenticated group to include auth middleware
+	// so the cookie is validated before streaming.
+	// We'll attach it below under auth.
 
 	auth := api.Group("/")
 	auth.Use(authpkg.Middleware(a))
 
-    // Settings/admin endpoints
-    // Keep GetSettings visible to authenticated users; restrict writes to admin
-    // to align with internal UI expectations.
-    auth.GET("/settings", handlers.GetSettings(db))
-    auth.POST("/settings/oidc", authpkg.RequireRole("admin"), handlers.SaveOIDCSettings(db))
-    auth.POST("/settings/storage", authpkg.RequireRole("admin"), handlers.SaveStorageSettings(db))
-    auth.POST("/settings/mail", authpkg.RequireRole("admin"), handlers.SaveMailSettings(db))
-    auth.POST("/test-connection", authpkg.RequireRole("admin"), handlers.TestConnection(db))
-    auth.GET("/events", eventspkg.Stream(a))
-    auth.GET("/me", authpkg.Me)
-    auth.GET("/tickets", ticketspkg.List(a))
-    auth.POST("/tickets", ticketspkg.Create(a))
+	// Settings/admin endpoints
+	// Keep GetSettings visible to authenticated users; restrict writes to admin
+	// to align with internal UI expectations.
+	auth.GET("/settings", handlers.GetSettings(db))
+	auth.POST("/settings/oidc", authpkg.RequireRole("admin"), handlers.SaveOIDCSettings(db))
+	auth.POST("/settings/storage", authpkg.RequireRole("admin"), handlers.SaveStorageSettings(db))
+	auth.POST("/settings/mail", authpkg.RequireRole("admin"), handlers.SaveMailSettings(db))
+	auth.POST("/test-connection", authpkg.RequireRole("admin"), handlers.TestConnection(db))
+	auth.GET("/events", eventspkg.Stream(a))
+	auth.GET("/me", authpkg.Me)
+	auth.POST("/requesters", requesterspkg.Create(a))
+	auth.GET("/requesters/:id", requesterspkg.Get(a))
+	auth.PATCH("/requesters/:id", requesterspkg.Update(a))
+	auth.GET("/tickets", ticketspkg.List(a))
+	auth.POST("/tickets", ticketspkg.Create(a))
 	auth.GET("/tickets/:id", ticketspkg.Get(a))
 	auth.PATCH("/tickets/:id", authpkg.RequireRole("agent", "manager"), ticketspkg.Update(a))
 	auth.GET("/tickets/:id/comments", commentspkg.List(a))
@@ -202,22 +210,22 @@ func main() {
 	auth.GET("/tickets/:id/watchers", watcherspkg.List(a))
 	auth.POST("/tickets/:id/watchers", watcherspkg.Add(a))
 	auth.DELETE("/tickets/:id/watchers/:userID", watcherspkg.Remove(a))
-    // Metrics and analytics
-    auth.GET("/metrics/agent", authpkg.RequireRole("agent"), metricspkg.Agent(a))
-    auth.GET("/metrics/manager", authpkg.RequireRole("manager"), metricspkg.Manager(a))
-    auth.GET("/metrics/sla", authpkg.RequireRole("agent"), metricspkg.SLA(a))
-    auth.GET("/metrics/resolution", authpkg.RequireRole("agent"), metricspkg.Resolution(a))
-    auth.GET("/metrics/tickets", authpkg.RequireRole("agent"), metricspkg.TicketVolume(a))
-    auth.POST("/exports/tickets", authpkg.RequireRole("agent"), exportspkg.Tickets(a))
+	// Metrics and analytics
+	auth.GET("/metrics/agent", authpkg.RequireRole("agent"), metricspkg.Agent(a))
+	auth.GET("/metrics/manager", authpkg.RequireRole("manager"), metricspkg.Manager(a))
+	auth.GET("/metrics/sla", authpkg.RequireRole("agent"), metricspkg.SLA(a))
+	auth.GET("/metrics/resolution", authpkg.RequireRole("agent"), metricspkg.Resolution(a))
+	auth.GET("/metrics/tickets", authpkg.RequireRole("agent"), metricspkg.TicketVolume(a))
+	auth.POST("/exports/tickets", authpkg.RequireRole("agent"), exportspkg.Tickets(a))
 
 	// Users listing (agent, manager, admin) and role management (admin only)
 	auth.GET("/users", authpkg.RequireRole("agent", "manager", "admin"), userspkg.List(a))
 	auth.GET("/users/:id", authpkg.RequireRole("agent", "manager", "admin"), userspkg.Get(a))
-    auth.POST("/users", authpkg.RequireRole("admin"), userspkg.CreateLocal(a))
-    auth.GET("/users/:id/roles", authpkg.RequireRole("admin"), authpkg.ListUserRoles(a))
-    auth.POST("/users/:id/roles", authpkg.RequireRole("admin"), authpkg.AddUserRole(a))
-    auth.DELETE("/users/:id/roles/:role", authpkg.RequireRole("admin"), authpkg.RemoveUserRole(a))
-    auth.GET("/roles", authpkg.RequireRole("admin"), rolespkg.List(a))
+	auth.POST("/users", authpkg.RequireRole("admin"), userspkg.CreateLocal(a))
+	auth.GET("/users/:id/roles", authpkg.RequireRole("admin"), authpkg.ListUserRoles(a))
+	auth.POST("/users/:id/roles", authpkg.RequireRole("admin"), authpkg.AddUserRole(a))
+	auth.DELETE("/users/:id/roles/:role", authpkg.RequireRole("admin"), authpkg.RemoveUserRole(a))
+	auth.GET("/roles", authpkg.RequireRole("admin"), rolespkg.List(a))
 
 	// Current user settings
 	auth.GET("/me/profile", userspkg.GetProfile(a))

--- a/cmd/api/migrations/0008_requesters_phone.sql
+++ b/cmd/api/migrations/0008_requesters_phone.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+alter table requesters add column if not exists phone text;
+
+-- +goose Down
+alter table requesters drop column if exists phone;

--- a/cmd/api/migrations/0009_tickets_requester_fk.sql
+++ b/cmd/api/migrations/0009_tickets_requester_fk.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+insert into requesters (id, email, name)
+    select distinct u.id, u.email, u.display_name
+    from tickets t
+    join users u on t.requester_id = u.id
+    where not exists (
+        select 1 from requesters r where r.id = u.id
+    );
+
+alter table tickets drop constraint if exists tickets_requester_id_fkey;
+alter table tickets add constraint tickets_requester_id_fkey foreign key (requester_id) references requesters(id);
+
+-- +goose Down
+alter table tickets drop constraint if exists tickets_requester_id_fkey;
+alter table tickets add constraint tickets_requester_id_fkey foreign key (requester_id) references users(id);

--- a/cmd/api/requesters/requesters.go
+++ b/cmd/api/requesters/requesters.go
@@ -126,15 +126,16 @@ func Update(a *app.App) gin.HandlerFunc {
 			args = append(args, *in.Name)
 			idx++
 		}
-		if in.Phone != nil {
-			if *in.Phone == "" || !ValidPhone(*in.Phone) {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_phone"})
-				return
-			}
-			set = append(set, fmt.Sprintf("phone=$%d", idx))
-			args = append(args, *in.Phone)
-			idx++
-		}
+    if in.Phone != nil {
+        if *in.Phone != "" && !ValidPhone(*in.Phone) {
+            c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_phone"})
+            return
+        }
+        // Store empty string as NULL for consistency with Create
+        set = append(set, fmt.Sprintf("phone=nullif($%d,'')", idx))
+        args = append(args, *in.Phone)
+        idx++
+    }
 		if a.DB == nil {
 			c.JSON(http.StatusOK, Requester{ID: c.Param("id")})
 			return

--- a/cmd/api/requesters/requesters.go
+++ b/cmd/api/requesters/requesters.go
@@ -1,0 +1,151 @@
+package requesters
+
+import (
+	"fmt"
+	"net/http"
+	"net/mail"
+	"regexp"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	app "github.com/mark3748/helpdesk-go/cmd/api/app"
+)
+
+// Requester represents a requester record.
+type Requester struct {
+	ID    string `json:"id"`
+	Email string `json:"email,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Phone string `json:"phone,omitempty"`
+}
+
+var phoneRe = regexp.MustCompile(`^\+?[0-9]{7,15}$`)
+
+// ValidEmail validates basic email format.
+func ValidEmail(e string) bool {
+	if e == "" {
+		return false
+	}
+	_, err := mail.ParseAddress(e)
+	return err == nil
+}
+
+// ValidPhone validates a simple international phone number.
+func ValidPhone(p string) bool {
+	if p == "" {
+		return false
+	}
+	return phoneRe.MatchString(p)
+}
+
+// Create inserts a requester.
+func Create(a *app.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var in struct {
+			Email string `json:"email"`
+			Name  string `json:"name"`
+			Phone string `json:"phone"`
+		}
+		if err := c.ShouldBindJSON(&in); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json"})
+			return
+		}
+		if in.Email == "" && in.Phone == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "email_or_phone_required"})
+			return
+		}
+		if in.Email != "" && !ValidEmail(in.Email) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_email"})
+			return
+		}
+		if in.Phone != "" && !ValidPhone(in.Phone) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_phone"})
+			return
+		}
+		if a.DB == nil {
+			c.JSON(http.StatusCreated, Requester{Email: in.Email, Name: in.Name, Phone: in.Phone})
+			return
+		}
+		const q = `insert into requesters (email, name, phone) values (nullif($1,''), nullif($2,''), nullif($3,'')) returning id::text, coalesce(email,''), coalesce(name,''), coalesce(phone,'')`
+		var r Requester
+		if err := a.DB.QueryRow(c.Request.Context(), q, strings.ToLower(in.Email), in.Name, in.Phone).Scan(&r.ID, &r.Email, &r.Name, &r.Phone); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusCreated, r)
+	}
+}
+
+// Get returns a requester by id.
+func Get(a *app.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if a.DB == nil {
+			c.JSON(http.StatusOK, Requester{ID: c.Param("id")})
+			return
+		}
+		const q = `select id::text, coalesce(email,''), coalesce(name,''), coalesce(phone,'') from requesters where id=$1`
+		var r Requester
+		if err := a.DB.QueryRow(c.Request.Context(), q, c.Param("id")).Scan(&r.ID, &r.Email, &r.Name, &r.Phone); err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusOK, r)
+	}
+}
+
+// Update modifies fields on a requester.
+func Update(a *app.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var in struct {
+			Email *string `json:"email"`
+			Name  *string `json:"name"`
+			Phone *string `json:"phone"`
+		}
+		if err := c.ShouldBindJSON(&in); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json"})
+			return
+		}
+		if in.Email == nil && in.Name == nil && in.Phone == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "no fields"})
+			return
+		}
+		set := []string{}
+		args := []any{}
+		idx := 1
+		if in.Email != nil {
+			if *in.Email == "" || !ValidEmail(*in.Email) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_email"})
+				return
+			}
+			set = append(set, fmt.Sprintf("email=$%d", idx))
+			args = append(args, strings.ToLower(*in.Email))
+			idx++
+		}
+		if in.Name != nil {
+			set = append(set, fmt.Sprintf("name=$%d", idx))
+			args = append(args, *in.Name)
+			idx++
+		}
+		if in.Phone != nil {
+			if *in.Phone == "" || !ValidPhone(*in.Phone) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_phone"})
+				return
+			}
+			set = append(set, fmt.Sprintf("phone=$%d", idx))
+			args = append(args, *in.Phone)
+			idx++
+		}
+		if a.DB == nil {
+			c.JSON(http.StatusOK, Requester{ID: c.Param("id")})
+			return
+		}
+		args = append(args, c.Param("id"))
+		sql := fmt.Sprintf("update requesters set %s where id=$%d returning id::text, coalesce(email,''), coalesce(name,''), coalesce(phone,'')", strings.Join(set, ","), idx)
+		var r Requester
+		if err := a.DB.QueryRow(c.Request.Context(), sql, args...).Scan(&r.ID, &r.Email, &r.Name, &r.Phone); err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusOK, r)
+	}
+}

--- a/cmd/api/requesters/requesters.go
+++ b/cmd/api/requesters/requesters.go
@@ -113,7 +113,7 @@ func Update(a *app.App) gin.HandlerFunc {
 		args := []any{}
 		idx := 1
 		if in.Email != nil {
-			if *in.Email == "" || !ValidEmail(*in.Email) {
+			if *in.Email != "" && !ValidEmail(*in.Email) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_email"})
 				return
 			}

--- a/cmd/api/requesters/requesters_test.go
+++ b/cmd/api/requesters/requesters_test.go
@@ -1,0 +1,48 @@
+package requesters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+)
+
+func TestRequesterHandlers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := apppkg.Config{Env: "test", TestBypassAuth: true}
+	a := apppkg.NewApp(cfg, nil, nil, nil, nil)
+	a.R.POST("/requesters", authpkg.Middleware(a), Create(a))
+	a.R.GET("/requesters/:id", authpkg.Middleware(a), Get(a))
+	a.R.PATCH("/requesters/:id", authpkg.Middleware(a), Update(a))
+
+	tests := []struct {
+		name   string
+		method string
+		url    string
+		body   string
+		want   int
+	}{
+		{"create", http.MethodPost, "/requesters", `{"email":"a@b.com","name":"Ann","phone":"+1234567890"}`, http.StatusCreated},
+		{"get", http.MethodGet, "/requesters/1", "", http.StatusOK},
+		{"update", http.MethodPatch, "/requesters/1", `{"name":"Bob"}`, http.StatusOK},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(tt.method, tt.url, strings.NewReader(tt.body))
+			if tt.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			a.R.ServeHTTP(rr, req)
+			if rr.Code != tt.want {
+				t.Fatalf("expected %d, got %d", tt.want, rr.Code)
+			}
+		})
+	}
+}

--- a/cmd/api/tickets/tickets.go
+++ b/cmd/api/tickets/tickets.go
@@ -165,7 +165,7 @@ returning id::text, number, title, status, assignee_id::text, priority`
 		t.RequesterID = in.RequesterID
 		// Best-effort fill requester label
 		if a.DB != nil {
-			_ = a.DB.QueryRow(c.Request.Context(), `select coalesce(display_name,''), coalesce(email,'') from users where id=$1`, in.RequesterID).Scan(&t.Requester, &t.Requester)
+			_ = a.DB.QueryRow(c.Request.Context(), `select coalesce(name,''), coalesce(email,'') from requesters where id=$1`, in.RequesterID).Scan(&t.Requester, &t.Requester)
 		}
 		c.JSON(http.StatusCreated, t)
 	}

--- a/cmd/api/tickets/tickets.go
+++ b/cmd/api/tickets/tickets.go
@@ -98,10 +98,6 @@ func Create(a *app.App) gin.HandlerFunc {
 				}
 			}
 		}
-		if in.RequesterID == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"errors": map[string]string{"requester_id": "required"}})
-			return
-		}
 		// Test mode: no DB attached, mimic previous behavior
 		if a.DB == nil {
 			c.JSON(http.StatusCreated, Ticket{Title: in.Title, Priority: in.Priority})

--- a/cmd/api/tickets/tickets.go
+++ b/cmd/api/tickets/tickets.go
@@ -13,6 +13,7 @@ import (
 
 	app "github.com/mark3748/helpdesk-go/cmd/api/app"
 	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+	requesterspkg "github.com/mark3748/helpdesk-go/cmd/api/requesters"
 )
 
 type Ticket struct {
@@ -29,9 +30,14 @@ type Ticket struct {
 
 // createTicketReq mirrors the JSON body for creating a ticket.
 type createTicketReq struct {
-	Title       string          `json:"title" binding:"required,min=3"`
-	Description string          `json:"description"`
-	RequesterID string          `json:"requester_id" binding:"required"`
+	Title       string `json:"title" binding:"required,min=3"`
+	Description string `json:"description"`
+	RequesterID string `json:"requester_id"`
+	Requester   *struct {
+		Email string `json:"email"`
+		Name  string `json:"name"`
+		Phone string `json:"phone"`
+	} `json:"requester"`
 	Priority    int16           `json:"priority" binding:"required,min=1,max=4"`
 	AssigneeID  *string         `json:"assignee_id"`
 	Urgency     *int16          `json:"urgency" binding:"omitempty,min=1,max=4"`
@@ -64,6 +70,37 @@ func Create(a *app.App) gin.HandlerFunc {
 				c.JSON(http.StatusBadRequest, gin.H{"errors": map[string]string{"custom_json": "must be object"}})
 				return
 			}
+		}
+		if in.RequesterID == "" {
+			if in.Requester == nil {
+				c.JSON(http.StatusBadRequest, gin.H{"errors": map[string]string{"requester": "required"}})
+				return
+			}
+			if in.Requester.Email == "" && in.Requester.Phone == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"errors": map[string]string{"requester": "email_or_phone"}})
+				return
+			}
+			if in.Requester.Email != "" && !requesterspkg.ValidEmail(in.Requester.Email) {
+				c.JSON(http.StatusBadRequest, gin.H{"errors": map[string]string{"email": "invalid"}})
+				return
+			}
+			if in.Requester.Phone != "" && !requesterspkg.ValidPhone(in.Requester.Phone) {
+				c.JSON(http.StatusBadRequest, gin.H{"errors": map[string]string{"phone": "invalid"}})
+				return
+			}
+			if a.DB == nil {
+				in.RequesterID = "1"
+			} else {
+				const rq = `insert into requesters (email, name, phone) values (nullif($1,''), nullif($2,''), nullif($3,'')) returning id::text`
+				if err := a.DB.QueryRow(c.Request.Context(), rq, strings.ToLower(in.Requester.Email), in.Requester.Name, in.Requester.Phone).Scan(&in.RequesterID); err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+					return
+				}
+			}
+		}
+		if in.RequesterID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"errors": map[string]string{"requester_id": "required"}})
+			return
 		}
 		// Test mode: no DB attached, mimic previous behavior
 		if a.DB == nil {

--- a/cmd/api/tickets/tickets_test.go
+++ b/cmd/api/tickets/tickets_test.go
@@ -31,6 +31,7 @@ func TestTicketHandlers(t *testing.T) {
 	}{
 		{"list", http.MethodGet, "/tickets", "", http.StatusOK},
 		{"create", http.MethodPost, "/tickets", `{"title":"abc","requester_id":"00000000-0000-0000-0000-000000000000","priority":1}`, http.StatusCreated},
+		{"create_inline", http.MethodPost, "/tickets", `{"title":"abc","requester":{"email":"a@b.com"},"priority":1}`, http.StatusCreated},
 		{"get", http.MethodGet, "/tickets/1", "", http.StatusOK},
 		{"update", http.MethodPut, "/tickets/1", `{}`, http.StatusOK},
 	}
@@ -45,7 +46,7 @@ func TestTicketHandlers(t *testing.T) {
 			if rr.Code != tt.want {
 				t.Fatalf("expected %d, got %d", tt.want, rr.Code)
 			}
-			if tt.name == "create" {
+			if tt.name == "create" || tt.name == "create_inline" {
 				var tk Ticket
 				if err := json.Unmarshal(rr.Body.Bytes(), &tk); err != nil || tk.Title != "abc" {
 					t.Fatalf("unexpected ticket: %v %v", tk, err)

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,9 +27,14 @@ Auth (local mode only)
 User
 - GET `/me` → 200 `{ id, external_id, email, display_name, roles }` | 401
 
+Requesters
+- POST `/requesters` body `{ email?, name?, phone? }` (email or phone required) → 201 `{ id }` | 400 | 500
+- GET `/requesters/:id` → 200 `{ id, email, name, phone }` | 404
+- PATCH `/requesters/:id` body partial `{ email?, name?, phone? }` → 200 `{ id }` | 400 | 404 | 500
+
 Tickets
 - GET `/tickets` query `status,priority,team,assignee,search` → 200 `[Ticket]` | 500
-- POST `/tickets` body `{ title, description, requester_id, priority, urgency?, category?, subcategory?, custom_json? }` → 201 `{ id, number, status }` | 400 | 500
+- POST `/tickets` body `{ title, description, requester_id?, requester?, priority, urgency?, category?, subcategory?, custom_json? }` → 201 `{ id, number, status }` | 400 | 500
   - `urgency` 1-4
   - `custom_json` object of additional fields
 - GET `/tickets/:id` → 200 `Ticket` | 404

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -160,12 +160,6 @@ components:
           type: object
           additionalProperties:
             type: string
-    Requester:
-      type: object
-      properties:
-        id: { type: string, format: uuid }
-        email: { type: string, format: email }
-        name: { type: string }
     Queue:
       type: object
       properties:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -91,13 +91,27 @@ components:
         bytes: { type: integer, format: int64 }
         mime: { type: string, nullable: true }
         created_at: { type: string, format: date-time }
+    Requester:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        email: { type: string, format: email }
+        name: { type: string }
+        phone: { type: string }
+    CreateRequesterRequest:
+      type: object
+      properties:
+        email: { type: string, format: email }
+        name: { type: string }
+        phone: { type: string }
     CreateTicketRequest:
       type: object
-      required: [title, requester_id, priority]
+      required: [title, priority]
       properties:
         title: { type: string }
         description: { type: string }
         requester_id: { type: string, format: uuid }
+        requester: { $ref: '#/components/schemas/CreateRequesterRequest' }
         priority: { type: integer, minimum: 1, maximum: 4 }
         urgency: { type: integer, minimum: 1, maximum: 4 }
         category: { type: string }
@@ -322,6 +336,70 @@ paths:
           schema: { type: string }
       responses:
         '200': { description: OK }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+  /requesters:
+    post:
+      tags: [Requesters]
+      summary: Create requester
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateRequesterRequest' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Requester' }
+        '400': { description: Validation error }
+        '500': { description: Server Error }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+  /requesters/{id}:
+    get:
+      tags: [Requesters]
+      summary: Get requester
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Requester' }
+        '404': { description: Not Found }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+    patch:
+      tags: [Requesters]
+      summary: Update requester
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateRequesterRequest' }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Requester' }
+        '400': { description: Validation error }
+        '404': { description: Not Found }
         '500': { description: Server Error }
       security:
         - bearerAuth: []


### PR DESCRIPTION
## Summary
- add requesters POST/GET/PATCH handlers with email and phone validation
- allow creating tickets with requester_id or inline requester payload
- document requester endpoints and inline ticket option

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./...`

------
https://chatgpt.com/codex/tasks/task_e_68b7f9fda0808322bfdb3beb8484b78e