### PR TITLE
api: register requester routes and fix ticket requester FK

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -19,21 +19,22 @@ import (
 	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
 	attachmentspkg "github.com/mark3748/helpdesk-go/cmd/api/attachments"
 	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
-	handlers "github.com/mark3748/helpdesk-go/cmd/api/handlers"
 	commentspkg "github.com/mark3748/helpdesk-go/cmd/api/comments"
-	exportspkg "github.com/mark3748/helpdesk-go/cmd/api/exports"
-	metricspkg "github.com/mark3748/helpdesk-go/cmd/api/metrics"
 	eventspkg "github.com/mark3748/helpdesk-go/cmd/api/events"
+	exportspkg "github.com/mark3748/helpdesk-go/cmd/api/exports"
+	handlers "github.com/mark3748/helpdesk-go/cmd/api/handlers"
+	metricspkg "github.com/mark3748/helpdesk-go/cmd/api/metrics"
 	migratepkg "github.com/mark3748/helpdesk-go/cmd/api/migrations"
+	requesterspkg "github.com/mark3748/helpdesk-go/cmd/api/requesters"
 	rolespkg "github.com/mark3748/helpdesk-go/cmd/api/roles"
-	userspkg "github.com/mark3748/helpdesk-go/cmd/api/users"
 	ticketspkg "github.com/mark3748/helpdesk-go/cmd/api/tickets"
+	userspkg "github.com/mark3748/helpdesk-go/cmd/api/users"
 	watcherspkg "github.com/mark3748/helpdesk-go/cmd/api/watchers"
 )
 
 func main() {
-    cfg := apppkg.GetConfig()
-    writer := io.Writer(os.Stdout)
+	cfg := apppkg.GetConfig()
+	writer := io.Writer(os.Stdout)
 	if cfg.Env == "dev" {
 		writer = zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
 	}
@@ -106,34 +107,38 @@ func main() {
 	}
 	defer rdb.Close()
 
-    a := apppkg.NewApp(cfg, db, keyf, store, rdb)
+	a := apppkg.NewApp(cfg, db, keyf, store, rdb)
 
-    // Serve OpenAPI spec and Swagger UI
-    a.R.GET("/openapi.yaml", func(c *gin.Context) {
-        // Resolve spec path: env override, repo-local, then image path
-        candidates := []string{}
-        if cfg.OpenAPISpecPath != "" { candidates = append(candidates, cfg.OpenAPISpecPath) }
-        candidates = append(candidates, "docs/openapi.yaml", "/opt/helpdesk/docs/openapi.yaml")
-        var content []byte
-        for _, p := range candidates {
-            if p == "" { continue }
-            if b, err := os.ReadFile(p); err == nil {
-                content = b
-                break
-            }
-        }
-        if len(content) == 0 {
-            c.AbortWithStatusJSON(404, gin.H{"error": "openapi not found"})
-            return
-        }
-        c.Data(200, "application/yaml", content)
-    })
-    // Conditionally serve local swagger assets if present; fall back to CDN via /docs page
-    if _, err := os.Stat("/opt/helpdesk/swagger"); err == nil {
-        a.R.Static("/swagger", "/opt/helpdesk/swagger")
-    }
-    a.R.GET("/docs", func(c *gin.Context) {
-        html := `<!doctype html>
+	// Serve OpenAPI spec and Swagger UI
+	a.R.GET("/openapi.yaml", func(c *gin.Context) {
+		// Resolve spec path: env override, repo-local, then image path
+		candidates := []string{}
+		if cfg.OpenAPISpecPath != "" {
+			candidates = append(candidates, cfg.OpenAPISpecPath)
+		}
+		candidates = append(candidates, "docs/openapi.yaml", "/opt/helpdesk/docs/openapi.yaml")
+		var content []byte
+		for _, p := range candidates {
+			if p == "" {
+				continue
+			}
+			if b, err := os.ReadFile(p); err == nil {
+				content = b
+				break
+			}
+		}
+		if len(content) == 0 {
+			c.AbortWithStatusJSON(404, gin.H{"error": "openapi not found"})
+			return
+		}
+		c.Data(200, "application/yaml", content)
+	})
+	// Conditionally serve local swagger assets if present; fall back to CDN via /docs page
+	if _, err := os.Stat("/opt/helpdesk/swagger"); err == nil {
+		a.R.Static("/swagger", "/opt/helpdesk/swagger")
+	}
+	a.R.GET("/docs", func(c *gin.Context) {
+		html := `<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -161,36 +166,39 @@ func main() {
     </script>
   </body>
 </html>`
-        c.Data(200, "text/html; charset=utf-8", []byte(html))
-    })
+		c.Data(200, "text/html; charset=utf-8", []byte(html))
+	})
 
-    // Public and authenticated API endpoints are mounted under /api
-    api := a.R.Group("/api")
-    api.GET("/healthz", func(c *gin.Context) { c.JSON(200, gin.H{"ok": true}) })
-    // Basic auth endpoints
-    api.POST("/login", authpkg.Login(a))
-    api.POST("/logout", authpkg.Logout())
+	// Public and authenticated API endpoints are mounted under /api
+	api := a.R.Group("/api")
+	api.GET("/healthz", func(c *gin.Context) { c.JSON(200, gin.H{"ok": true}) })
+	// Basic auth endpoints
+	api.POST("/login", authpkg.Login(a))
+	api.POST("/logout", authpkg.Logout())
 
-    // Public SSE (requires auth cookie; still under auth group)
-    // NOTE: Expose under authenticated group to include auth middleware
-    // so the cookie is validated before streaming.
-    // We'll attach it below under auth.
+	// Public SSE (requires auth cookie; still under auth group)
+	// NOTE: Expose under authenticated group to include auth middleware
+	// so the cookie is validated before streaming.
+	// We'll attach it below under auth.
 
 	auth := api.Group("/")
 	auth.Use(authpkg.Middleware(a))
 
-    // Settings/admin endpoints
-    // Keep GetSettings visible to authenticated users; restrict writes to admin
-    // to align with internal UI expectations.
-    auth.GET("/settings", handlers.GetSettings(db))
-    auth.POST("/settings/oidc", authpkg.RequireRole("admin"), handlers.SaveOIDCSettings(db))
-    auth.POST("/settings/storage", authpkg.RequireRole("admin"), handlers.SaveStorageSettings(db))
-    auth.POST("/settings/mail", authpkg.RequireRole("admin"), handlers.SaveMailSettings(db))
-    auth.POST("/test-connection", authpkg.RequireRole("admin"), handlers.TestConnection(db))
-    auth.GET("/events", eventspkg.Stream(a))
-    auth.GET("/me", authpkg.Me)
-    auth.GET("/tickets", ticketspkg.List(a))
-    auth.POST("/tickets", ticketspkg.Create(a))
+	// Settings/admin endpoints
+	// Keep GetSettings visible to authenticated users; restrict writes to admin
+	// to align with internal UI expectations.
+	auth.GET("/settings", handlers.GetSettings(db))
+	auth.POST("/settings/oidc", authpkg.RequireRole("admin"), handlers.SaveOIDCSettings(db))
+	auth.POST("/settings/storage", authpkg.RequireRole("admin"), handlers.SaveStorageSettings(db))
+	auth.POST("/settings/mail", authpkg.RequireRole("admin"), handlers.SaveMailSettings(db))
+	auth.POST("/test-connection", authpkg.RequireRole("admin"), handlers.TestConnection(db))
+	auth.GET("/events", eventspkg.Stream(a))
+	auth.GET("/me", authpkg.Me)
+	auth.POST("/requesters", requesterspkg.Create(a))
+	auth.GET("/requesters/:id", requesterspkg.Get(a))
+	auth.PATCH("/requesters/:id", requesterspkg.Update(a))
+	auth.GET("/tickets", ticketspkg.List(a))
+	auth.POST("/tickets", ticketspkg.Create(a))
 	auth.GET("/tickets/:id", ticketspkg.Get(a))
 	auth.PATCH("/tickets/:id", authpkg.RequireRole("agent", "manager"), ticketspkg.Update(a))
 	auth.GET("/tickets/:id/comments", commentspkg.List(a))
@@ -202,22 +210,22 @@ func main() {
 	auth.GET("/tickets/:id/watchers", watcherspkg.List(a))
 	auth.POST("/tickets/:id/watchers", watcherspkg.Add(a))
 	auth.DELETE("/tickets/:id/watchers/:userID", watcherspkg.Remove(a))
-    // Metrics and analytics
-    auth.GET("/metrics/agent", authpkg.RequireRole("agent"), metricspkg.Agent(a))
-    auth.GET("/metrics/manager", authpkg.RequireRole("manager"), metricspkg.Manager(a))
-    auth.GET("/metrics/sla", authpkg.RequireRole("agent"), metricspkg.SLA(a))
-    auth.GET("/metrics/resolution", authpkg.RequireRole("agent"), metricspkg.Resolution(a))
-    auth.GET("/metrics/tickets", authpkg.RequireRole("agent"), metricspkg.TicketVolume(a))
-    auth.POST("/exports/tickets", authpkg.RequireRole("agent"), exportspkg.Tickets(a))
+	// Metrics and analytics
+	auth.GET("/metrics/agent", authpkg.RequireRole("agent"), metricspkg.Agent(a))
+	auth.GET("/metrics/manager", authpkg.RequireRole("manager"), metricspkg.Manager(a))
+	auth.GET("/metrics/sla", authpkg.RequireRole("agent"), metricspkg.SLA(a))
+	auth.GET("/metrics/resolution", authpkg.RequireRole("agent"), metricspkg.Resolution(a))
+	auth.GET("/metrics/tickets", authpkg.RequireRole("agent"), metricspkg.TicketVolume(a))
+	auth.POST("/exports/tickets", authpkg.RequireRole("agent"), exportspkg.Tickets(a))
 
 	// Users listing (agent, manager, admin) and role management (admin only)
 	auth.GET("/users", authpkg.RequireRole("agent", "manager", "admin"), userspkg.List(a))
 	auth.GET("/users/:id", authpkg.RequireRole("agent", "manager", "admin"), userspkg.Get(a))
-    auth.POST("/users", authpkg.RequireRole("admin"), userspkg.CreateLocal(a))
-    auth.GET("/users/:id/roles", authpkg.RequireRole("admin"), authpkg.ListUserRoles(a))
-    auth.POST("/users/:id/roles", authpkg.RequireRole("admin"), authpkg.AddUserRole(a))
-    auth.DELETE("/users/:id/roles/:role", authpkg.RequireRole("admin"), authpkg.RemoveUserRole(a))
-    auth.GET("/roles", authpkg.RequireRole("admin"), rolespkg.List(a))
+	auth.POST("/users", authpkg.RequireRole("admin"), userspkg.CreateLocal(a))
+	auth.GET("/users/:id/roles", authpkg.RequireRole("admin"), authpkg.ListUserRoles(a))
+	auth.POST("/users/:id/roles", authpkg.RequireRole("admin"), authpkg.AddUserRole(a))
+	auth.DELETE("/users/:id/roles/:role", authpkg.RequireRole("admin"), authpkg.RemoveUserRole(a))
+	auth.GET("/roles", authpkg.RequireRole("admin"), rolespkg.List(a))
 
 	// Current user settings
 	auth.GET("/me/profile", userspkg.GetProfile(a))

--- a/cmd/api/migrations/0009_tickets_requester_fk.sql
+++ b/cmd/api/migrations/0009_tickets_requester_fk.sql
@@ -1,4 +1,12 @@
 -- +goose Up
+insert into requesters (id, email, name)
+    select distinct u.id, u.email, u.display_name
+    from tickets t
+    join users u on t.requester_id = u.id
+    where not exists (
+        select 1 from requesters r where r.id = u.id
+    );
+
 alter table tickets drop constraint if exists tickets_requester_id_fkey;
 alter table tickets add constraint tickets_requester_id_fkey foreign key (requester_id) references requesters(id);
 

--- a/cmd/api/migrations/0009_tickets_requester_fk.sql
+++ b/cmd/api/migrations/0009_tickets_requester_fk.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+alter table tickets drop constraint if exists tickets_requester_id_fkey;
+alter table tickets add constraint tickets_requester_id_fkey foreign key (requester_id) references requesters(id);
+
+-- +goose Down
+alter table tickets drop constraint if exists tickets_requester_id_fkey;
+alter table tickets add constraint tickets_requester_id_fkey foreign key (requester_id) references users(id);

--- a/cmd/api/tickets/tickets.go
+++ b/cmd/api/tickets/tickets.go
@@ -165,7 +165,7 @@ returning id::text, number, title, status, assignee_id::text, priority`
 		t.RequesterID = in.RequesterID
 		// Best-effort fill requester label
 		if a.DB != nil {
-			_ = a.DB.QueryRow(c.Request.Context(), `select coalesce(display_name,''), coalesce(email,'') from users where id=$1`, in.RequesterID).Scan(&t.Requester, &t.Requester)
+			_ = a.DB.QueryRow(c.Request.Context(), `select coalesce(name,''), coalesce(email,'') from requesters where id=$1`, in.RequesterID).Scan(&t.Requester, &t.Requester)
 		}
 		c.JSON(http.StatusCreated, t)
 	}


### PR DESCRIPTION
## Summary
- mount requester endpoints in API router
- link tickets.requester_id to requesters table and query labels from requesters

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b7fdc0edd48322823d869a2c6a835c