### PR TITLE
api: register requester routes and fix ticket requester FK

### DIFF
--- a/cmd/api/migrations/0009_tickets_requester_fk.sql
+++ b/cmd/api/migrations/0009_tickets_requester_fk.sql
@@ -1,4 +1,12 @@
 -- +goose Up
+insert into requesters (id, email, name)
+    select distinct u.id, u.email, u.display_name
+    from tickets t
+    join users u on t.requester_id = u.id
+    where not exists (
+        select 1 from requesters r where r.id = u.id
+    );
+
 alter table tickets drop constraint if exists tickets_requester_id_fkey;
 alter table tickets add constraint tickets_requester_id_fkey foreign key (requester_id) references requesters(id);
 


### PR DESCRIPTION
## Summary
- mount requester endpoints in API router
- link tickets.requester_id to requesters table and query labels from requesters
- seed requesters from existing tickets before enforcing FK

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./...` *(fails: hangs without output)*


------
https://chatgpt.com/codex/tasks/task_e_68b864c516a48322a15e6c4656ac946a