### PR TITLE
migrations: guard requester seed insert from email conflicts

### DIFF
--- a/cmd/api/migrations/0009_tickets_requester_fk.sql
+++ b/cmd/api/migrations/0009_tickets_requester_fk.sql
@@ -5,7 +5,8 @@ insert into requesters (id, email, name)
     join users u on t.requester_id = u.id
     where not exists (
         select 1 from requesters r where r.id = u.id
-    );
+    )
+on conflict (email) do nothing;
 
 alter table tickets drop constraint if exists tickets_requester_id_fkey;
 alter table tickets add constraint tickets_requester_id_fkey foreign key (requester_id) references requesters(id);


### PR DESCRIPTION
## Summary
- avoid unique email violations when seeding requesters

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8666fbfec83229cd5ffbd8014b806