### PR TITLE
tickets: add cursor pagination and filters

### DIFF
--- a/cmd/api/migrations/0010_ticket_indexes.sql
+++ b/cmd/api/migrations/0010_ticket_indexes.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+create index if not exists tickets_updated_at_id_idx on tickets (updated_at desc, id desc);
+create index if not exists tickets_status_idx on tickets(status);
+create index if not exists tickets_priority_idx on tickets(priority);
+create index if not exists tickets_team_id_idx on tickets(team_id);
+create index if not exists tickets_assignee_id_idx on tickets(assignee_id);
+-- +goose Down
+drop index if exists tickets_assignee_id_idx;
+drop index if exists tickets_team_id_idx;
+drop index if exists tickets_priority_idx;
+drop index if exists tickets_status_idx;
+drop index if exists tickets_updated_at_id_idx;

--- a/cmd/api/tickets/tickets.go
+++ b/cmd/api/tickets/tickets.go
@@ -319,10 +319,10 @@ func List(a *app.App) gin.HandlerFunc {
 
 		var next string
 		if len(out) > limit {
-			last := out[len(out)-1]
-			lastUp := ups[len(ups)-1]
+			last := out[limit-1]
+			lastUp := ups[limit-1]
 			next = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s,%s", lastUp.UTC().Format(time.RFC3339Nano), last.ID)))
-			out = out[:len(out)-1]
+			out = out[:limit]
 		}
 
 		c.JSON(http.StatusOK, gin.H{"tickets": out, "next_cursor": next})

--- a/cmd/api/tickets/tickets.go
+++ b/cmd/api/tickets/tickets.go
@@ -233,7 +233,7 @@ func List(a *app.App) gin.HandlerFunc {
 
 		if teams := getMulti("team"); len(teams) > 0 {
 			n := len(args) + 1
-			where = append(where, fmt.Sprintf("t.team_id = ANY($%d)", n))
+			where = append(where, fmt.Sprintf("t.team_id = ANY($%d::uuid[])", n))
 			args = append(args, teams)
 		}
 
@@ -243,19 +243,19 @@ func List(a *app.App) gin.HandlerFunc {
 		}
 		if len(assignees) > 0 {
 			n := len(args) + 1
-			where = append(where, fmt.Sprintf("t.assignee_id = ANY($%d)", n))
+			where = append(where, fmt.Sprintf("t.assignee_id = ANY($%d::uuid[])", n))
 			args = append(args, assignees)
 		}
 
 		if reqs := getMulti("requester"); len(reqs) > 0 {
 			n := len(args) + 1
-			where = append(where, fmt.Sprintf("t.requester_id = ANY($%d)", n))
+			where = append(where, fmt.Sprintf("t.requester_id = ANY($%d::uuid[])", n))
 			args = append(args, reqs)
 		}
 
 		if qs := getMulti("queue"); len(qs) > 0 {
 			n := len(args) + 1
-			where = append(where, fmt.Sprintf("t.queue_id = ANY($%d)", n))
+			where = append(where, fmt.Sprintf("t.queue_id = ANY($%d::uuid[])", n))
 			args = append(args, qs)
 		}
 


### PR DESCRIPTION
## Summary
- paginate ticket list using updated_at,id cursor with multi-value filters
- add default closed-ticket exclusion and next_cursor in API response
- add indexes for pagination and filtering

## Testing
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b87108c4788322b45c54438711d2fa