### PR TITLE
api: stream ticket events with resume support

### DIFF
--- a/cmd/api/attachments/attachments.go
+++ b/cmd/api/attachments/attachments.go
@@ -1,162 +1,172 @@
 package attachments
 
 import (
-    "os"
-    "mime"
-    "net/http"
-    "path/filepath"
-    "strings"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 
-    "github.com/gin-gonic/gin"
-    "github.com/google/uuid"
-    "github.com/minio/minio-go/v7"
-    app "github.com/mark3748/helpdesk-go/cmd/api/app"
-    authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	app "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+	eventspkg "github.com/mark3748/helpdesk-go/cmd/api/events"
+	"github.com/minio/minio-go/v7"
 )
 
 func List(a *app.App) gin.HandlerFunc {
-    return func(c *gin.Context) {
-        if a.DB == nil {
-            c.JSON(http.StatusOK, []any{})
-            return
-        }
-        const q = `select id::text, filename, bytes from attachments where ticket_id=$1 order by created_at asc`
-        rows, err := a.DB.Query(c.Request.Context(), q, c.Param("id"))
-        if err != nil {
-            c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-            return
-        }
-        defer rows.Close()
-        type att struct{ ID string `json:"id"`; Filename string `json:"filename"`; Bytes int64 `json:"bytes"` }
-        var out []att
-        for rows.Next() {
-            var a1 att
-            if err := rows.Scan(&a1.ID, &a1.Filename, &a1.Bytes); err != nil {
-                c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-                return
-            }
-            out = append(out, a1)
-        }
-        c.JSON(http.StatusOK, out)
-    }
+	return func(c *gin.Context) {
+		if a.DB == nil {
+			c.JSON(http.StatusOK, []any{})
+			return
+		}
+		const q = `select id::text, filename, bytes from attachments where ticket_id=$1 order by created_at asc`
+		rows, err := a.DB.Query(c.Request.Context(), q, c.Param("id"))
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer rows.Close()
+		type att struct {
+			ID       string `json:"id"`
+			Filename string `json:"filename"`
+			Bytes    int64  `json:"bytes"`
+		}
+		var out []att
+		for rows.Next() {
+			var a1 att
+			if err := rows.Scan(&a1.ID, &a1.Filename, &a1.Bytes); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			out = append(out, a1)
+		}
+		c.JSON(http.StatusOK, out)
+	}
 }
 
 func Upload(a *app.App) gin.HandlerFunc {
-    return func(c *gin.Context) {
-        if a.DB == nil || a.M == nil {
-            c.JSON(http.StatusCreated, gin.H{"id": "temp"})
-            return
-        }
-        f, header, err := c.Request.FormFile("file")
-        if err != nil {
-            c.JSON(http.StatusBadRequest, gin.H{"error": "file required"})
-            return
-        }
-        defer f.Close()
-        safeName := sanitizeFilename(header.Filename)
-        if safeName == "" { safeName = "file" }
-        key := uuid.New().String() + "-" + safeName
-        size := header.Size
-        ct := header.Header.Get("Content-Type")
-        if ct == "" { ct = mime.TypeByExtension(filepath.Ext(header.Filename)) }
-        if _, err := a.M.PutObject(c.Request.Context(), a.Cfg.MinIOBucket, key, f, size, minio.PutObjectOptions{ContentType: ct}); err != nil {
-            c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-            return
-        }
-        const q = `insert into attachments (ticket_id, uploader_id, object_key, filename, bytes) values ($1, $2, $3, $4, $5) returning id::text`
-        var id string
-        // Use current authenticated user's ID as uploader
-        var uploader string
-        if v, ok := c.Get("user"); ok {
-            if u, ok := v.(authpkg.AuthUser); ok {
-                uploader = u.ID
-            }
-        }
-        if uploader == "" {
-            c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
-            return
-        }
-        if err := a.DB.QueryRow(c.Request.Context(), q, c.Param("id"), uploader, key, header.Filename, size).Scan(&id); err != nil {
-            c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-            return
-        }
-        c.JSON(http.StatusCreated, gin.H{"id": id})
-    }
+	return func(c *gin.Context) {
+		if a.DB == nil || a.M == nil {
+			c.JSON(http.StatusCreated, gin.H{"id": "temp"})
+			return
+		}
+		f, header, err := c.Request.FormFile("file")
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "file required"})
+			return
+		}
+		defer f.Close()
+		safeName := sanitizeFilename(header.Filename)
+		if safeName == "" {
+			safeName = "file"
+		}
+		key := uuid.New().String() + "-" + safeName
+		size := header.Size
+		ct := header.Header.Get("Content-Type")
+		if ct == "" {
+			ct = mime.TypeByExtension(filepath.Ext(header.Filename))
+		}
+		if _, err := a.M.PutObject(c.Request.Context(), a.Cfg.MinIOBucket, key, f, size, minio.PutObjectOptions{ContentType: ct}); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		const q = `insert into attachments (ticket_id, uploader_id, object_key, filename, bytes) values ($1, $2, $3, $4, $5) returning id::text`
+		var id string
+		// Use current authenticated user's ID as uploader
+		var uploader string
+		if v, ok := c.Get("user"); ok {
+			if u, ok := v.(authpkg.AuthUser); ok {
+				uploader = u.ID
+			}
+		}
+		if uploader == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+			return
+		}
+		if err := a.DB.QueryRow(c.Request.Context(), q, c.Param("id"), uploader, key, header.Filename, size).Scan(&id); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		eventspkg.Emit(c.Request.Context(), a.DB, c.Param("id"), "ticket_updated", map[string]any{"id": c.Param("id")})
+		c.JSON(http.StatusCreated, gin.H{"id": id})
+	}
 }
 
 func Get(a *app.App) gin.HandlerFunc {
-    return func(c *gin.Context) {
-        if a.DB == nil {
-            c.JSON(http.StatusOK, gin.H{"id": c.Param("attID")})
-            return
-        }
-        const q = `select object_key, filename, bytes from attachments where id=$1 and ticket_id=$2`
-        var key, fn string
-        var size int64
-        if err := a.DB.QueryRow(c.Request.Context(), q, c.Param("attID"), c.Param("id")).Scan(&key, &fn, &size); err != nil {
-            c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-            return
-        }
-        // Serve from filesystem store when configured
-        if fs, ok := a.M.(*app.FsObjectStore); ok {
-            root := filepath.Join(fs.Base, a.Cfg.MinIOBucket)
-            path := filepath.Clean(filepath.Join(root, key))
-            // Ensure the path is within the root (prevent traversal)
-            if rel, err := filepath.Rel(root, path); err != nil || strings.HasPrefix(rel, "..") {
-                c.JSON(http.StatusBadRequest, gin.H{"error": "invalid path"})
-                return
-            }
-            f, err := os.ReadFile(path)
-            if err != nil {
-                c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-                return
-            }
-            c.Writer.Header().Set("Content-Type", mime.TypeByExtension(filepath.Ext(fn)))
-            c.Writer.Header().Set("Content-Disposition", "attachment; filename=\""+strings.ReplaceAll(fn, "\"", "")+"\"")
-            _, _ = c.Writer.Write(f)
-            return
-        }
-        // Otherwise unimplemented (e.g., MinIO); client may handle 501
-        c.JSON(http.StatusNotImplemented, gin.H{"error": "download not implemented"})
-    }
+	return func(c *gin.Context) {
+		if a.DB == nil {
+			c.JSON(http.StatusOK, gin.H{"id": c.Param("attID")})
+			return
+		}
+		const q = `select object_key, filename, bytes from attachments where id=$1 and ticket_id=$2`
+		var key, fn string
+		var size int64
+		if err := a.DB.QueryRow(c.Request.Context(), q, c.Param("attID"), c.Param("id")).Scan(&key, &fn, &size); err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		// Serve from filesystem store when configured
+		if fs, ok := a.M.(*app.FsObjectStore); ok {
+			root := filepath.Join(fs.Base, a.Cfg.MinIOBucket)
+			path := filepath.Clean(filepath.Join(root, key))
+			// Ensure the path is within the root (prevent traversal)
+			if rel, err := filepath.Rel(root, path); err != nil || strings.HasPrefix(rel, "..") {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid path"})
+				return
+			}
+			f, err := os.ReadFile(path)
+			if err != nil {
+				c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+				return
+			}
+			c.Writer.Header().Set("Content-Type", mime.TypeByExtension(filepath.Ext(fn)))
+			c.Writer.Header().Set("Content-Disposition", "attachment; filename=\""+strings.ReplaceAll(fn, "\"", "")+"\"")
+			_, _ = c.Writer.Write(f)
+			return
+		}
+		// Otherwise unimplemented (e.g., MinIO); client may handle 501
+		c.JSON(http.StatusNotImplemented, gin.H{"error": "download not implemented"})
+	}
 }
 
 // sanitizeFilename removes path separators and dot segments and restricts to a
 // conservative character set, preserving the extension when possible.
 func sanitizeFilename(name string) string {
-    // Drop any path components
-    name = filepath.Base(name)
-    // Replace Windows separators too
-    name = strings.ReplaceAll(name, "\\", "_")
-    name = strings.ReplaceAll(name, "/", "_")
-    // Remove dot-dot sequences
-    name = strings.ReplaceAll(name, "..", "")
-    // Allow only letters, digits, space, dash, underscore, and dot
-    b := strings.Builder{}
-    for _, r := range name {
-        if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == ' ' || r == '-' || r == '_' || r == '.' {
-            b.WriteRune(r)
-        } else {
-            b.WriteByte('_')
-        }
-    }
-    out := strings.TrimSpace(b.String())
-    // Avoid empty or hidden names
-    out = strings.TrimLeft(out, ".")
-    return out
+	// Drop any path components
+	name = filepath.Base(name)
+	// Replace Windows separators too
+	name = strings.ReplaceAll(name, "\\", "_")
+	name = strings.ReplaceAll(name, "/", "_")
+	// Remove dot-dot sequences
+	name = strings.ReplaceAll(name, "..", "")
+	// Allow only letters, digits, space, dash, underscore, and dot
+	b := strings.Builder{}
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == ' ' || r == '-' || r == '_' || r == '.' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	// Avoid empty or hidden names
+	out = strings.TrimLeft(out, ".")
+	return out
 }
 
 func Delete(a *app.App) gin.HandlerFunc {
-    return func(c *gin.Context) {
-        if a.DB == nil {
-            c.JSON(http.StatusOK, gin.H{"ok": true})
-            return
-        }
-        const q = `delete from attachments where id=$1 and ticket_id=$2`
-        if _, err := a.DB.Exec(c.Request.Context(), q, c.Param("attID"), c.Param("id")); err != nil {
-            c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-            return
-        }
-        c.JSON(http.StatusOK, gin.H{"ok": true})
-    }
+	return func(c *gin.Context) {
+		if a.DB == nil {
+			c.JSON(http.StatusOK, gin.H{"ok": true})
+			return
+		}
+		const q = `delete from attachments where id=$1 and ticket_id=$2`
+		if _, err := a.DB.Exec(c.Request.Context(), q, c.Param("attID"), c.Param("id")); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	}
 }

--- a/cmd/api/comments/comments.go
+++ b/cmd/api/comments/comments.go
@@ -1,59 +1,66 @@
 package comments
 
 import (
-    "net/http"
+	"net/http"
 
-    "github.com/gin-gonic/gin"
-    app "github.com/mark3748/helpdesk-go/cmd/api/app"
-    authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+	"github.com/gin-gonic/gin"
+	app "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+	eventspkg "github.com/mark3748/helpdesk-go/cmd/api/events"
 )
 
 func List(a *app.App) gin.HandlerFunc {
-    return func(c *gin.Context) {
-        if a.DB == nil {
-            c.JSON(http.StatusOK, []any{})
-            return
-        }
-        const q = `select id::text, body_md from ticket_comments where ticket_id=$1 order by created_at asc`
-        rows, err := a.DB.Query(c.Request.Context(), q, c.Param("id"))
-        if err != nil {
-            c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-            return
-        }
-        defer rows.Close()
-        type resp struct{ ID string `json:"id"`; BodyMD string `json:"body_md"` }
-        var out []resp
-        for rows.Next() {
-            var r resp
-            if err := rows.Scan(&r.ID, &r.BodyMD); err != nil {
-                c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-                return
-            }
-            out = append(out, r)
-        }
-        c.JSON(http.StatusOK, out)
-    }
+	return func(c *gin.Context) {
+		if a.DB == nil {
+			c.JSON(http.StatusOK, []any{})
+			return
+		}
+		const q = `select id::text, body_md from ticket_comments where ticket_id=$1 order by created_at asc`
+		rows, err := a.DB.Query(c.Request.Context(), q, c.Param("id"))
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer rows.Close()
+		type resp struct {
+			ID     string `json:"id"`
+			BodyMD string `json:"body_md"`
+		}
+		var out []resp
+		for rows.Next() {
+			var r resp
+			if err := rows.Scan(&r.ID, &r.BodyMD); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			out = append(out, r)
+		}
+		c.JSON(http.StatusOK, out)
+	}
 }
 
 func Add(a *app.App) gin.HandlerFunc {
-    return func(c *gin.Context) {
-        if a.DB == nil {
-            c.JSON(http.StatusCreated, gin.H{"id": "temp"})
-            return
-        }
-        var in struct{ BodyMD string `json:"body_md"` }
-        if err := c.ShouldBindJSON(&in); err != nil || in.BodyMD == "" {
-            c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json"})
-            return
-        }
-        uVal, _ := c.Get("user")
-        au, _ := uVal.(authpkg.AuthUser)
-        const q = `insert into ticket_comments (ticket_id, author_id, body_md) values ($1, $2, $3) returning id::text`
-        var id string
-        if err := a.DB.QueryRow(c.Request.Context(), q, c.Param("id"), au.ID, in.BodyMD).Scan(&id); err != nil {
-            c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-            return
-        }
-        c.JSON(http.StatusCreated, gin.H{"id": id})
-    }
+	return func(c *gin.Context) {
+		if a.DB == nil {
+			c.JSON(http.StatusCreated, gin.H{"id": "temp"})
+			return
+		}
+		var in struct {
+			BodyMD string `json:"body_md"`
+		}
+		if err := c.ShouldBindJSON(&in); err != nil || in.BodyMD == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json"})
+			return
+		}
+		uVal, _ := c.Get("user")
+		au, _ := uVal.(authpkg.AuthUser)
+		const q = `insert into ticket_comments (ticket_id, author_id, body_md) values ($1, $2, $3) returning id::text`
+		var id string
+		if err := a.DB.QueryRow(c.Request.Context(), q, c.Param("id"), au.ID, in.BodyMD).Scan(&id); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		eventspkg.Emit(c.Request.Context(), a.DB, c.Param("id"), "ticket_updated", map[string]any{"id": c.Param("id")})
+		c.JSON(http.StatusCreated, gin.H{"id": id})
+	}
 }

--- a/cmd/api/events/emit.go
+++ b/cmd/api/events/emit.go
@@ -1,0 +1,21 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+)
+
+// Emit records a ticket event in the database. Best effort; errors are ignored.
+func Emit(ctx context.Context, db apppkg.DB, ticketID, typ string, data interface{}) {
+	if db == nil {
+		return
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+	const q = `insert into ticket_events (ticket_id, event_type, payload) values ($1, $2, $3)`
+	_, _ = db.Exec(ctx, q, ticketID, typ, b)
+}

--- a/cmd/api/events/events.go
+++ b/cmd/api/events/events.go
@@ -1,48 +1,92 @@
 package events
 
 import (
-    "time"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
 
-    "github.com/gin-gonic/gin"
-
-    apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	"github.com/gin-gonic/gin"
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
 )
 
-// Stream provides a minimal SSE endpoint that maintains a connection
-// and sends periodic heartbeats. Specific domain events can be wired in later.
-func Stream(a *apppkg.App) gin.HandlerFunc {
-    _ = a
-    return func(c *gin.Context) {
-        // Standard SSE headers
-        c.Writer.Header().Set("Content-Type", "text/event-stream")
-        c.Writer.Header().Set("Cache-Control", "no-cache")
-        c.Writer.Header().Set("Connection", "keep-alive")
-        c.Writer.Header().Set("X-Content-Type-Options", "nosniff")
-
-        // Flush initial comment to open the stream
-        c.Writer.WriteHeader(200)
-        if flusher, ok := c.Writer.(gin.ResponseWriter); ok {
-            flusher.Flush()
-        } else if f, ok := c.Writer.(interface{ Flush() }); ok {
-            f.Flush()
-        }
-
-        ticker := time.NewTicker(25 * time.Second)
-        defer ticker.Stop()
-
-        // Heartbeat loop
-        for {
-            select {
-            case <-c.Request.Context().Done():
-                return
-            case t := <-ticker.C:
-                // send a lightweight ping to keep the connection alive
-                c.SSEvent("ping", gin.H{"t": t.Unix()})
-                if f, ok := c.Writer.(interface{ Flush() }); ok {
-                    f.Flush()
-                }
-            }
-        }
-    }
+// Envelope is the standardized event payload sent to clients.
+type Envelope struct {
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data,omitempty"`
 }
 
+// Stream broadcasts ticket events from the database using Server-Sent Events.
+// It supports resuming from the Last-Event-ID header and emits periodic
+// heartbeat comments to keep connections alive.
+func Stream(a *apppkg.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if a.DB == nil {
+			c.Status(http.StatusOK)
+			return
+		}
+		// Standard SSE headers
+		c.Writer.Header().Set("Content-Type", "text/event-stream")
+		c.Writer.Header().Set("Cache-Control", "no-cache")
+		c.Writer.Header().Set("Connection", "keep-alive")
+		c.Writer.Header().Set("X-Content-Type-Options", "nosniff")
+
+		flusher, ok := c.Writer.(http.Flusher)
+		if !ok {
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+
+		ctx := c.Request.Context()
+
+		// Determine starting point based on Last-Event-ID
+		last := time.Time{}
+		if id := c.GetHeader("Last-Event-ID"); id != "" {
+			_ = a.DB.QueryRow(ctx, `select created_at from ticket_events where id=$1`, id).Scan(&last)
+		}
+
+		// Helper to send all events newer than the provided time.
+		send := func(since time.Time) time.Time {
+			rows, err := a.DB.Query(ctx, `select id::text, event_type, payload, created_at from ticket_events where created_at > $1 order by created_at asc`, since)
+			if err != nil {
+				return since
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var id, typ string
+				var payload []byte
+				var ts time.Time
+				if err := rows.Scan(&id, &typ, &payload, &ts); err != nil {
+					continue
+				}
+				env := Envelope{Type: typ, Data: payload}
+				b, _ := json.Marshal(env)
+				fmt.Fprintf(c.Writer, "id: %s\n", id)
+				fmt.Fprintf(c.Writer, "event: %s\n", typ)
+				fmt.Fprintf(c.Writer, "data: %s\n\n", b)
+				flusher.Flush()
+				since = ts
+			}
+			return since
+		}
+
+		last = send(last)
+
+		poll := time.NewTicker(time.Second)
+		heart := time.NewTicker(25 * time.Second)
+		defer poll.Stop()
+		defer heart.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-poll.C:
+				last = send(last)
+			case <-heart.C:
+				fmt.Fprint(c.Writer, ": heartbeat\n\n")
+				flusher.Flush()
+			}
+		}
+	}
+}

--- a/cmd/api/events/events.go
+++ b/cmd/api/events/events.go
@@ -20,11 +20,11 @@ type Envelope struct {
 // It supports resuming from the Last-Event-ID header and emits periodic
 // heartbeat comments to keep connections alive.
 func Stream(a *apppkg.App) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		if a.DB == nil {
-			c.Status(http.StatusOK)
-			return
-		}
+    return func(c *gin.Context) {
+        if a.DB == nil {
+            c.Status(http.StatusOK)
+            return
+        }
 		// Standard SSE headers
 		c.Writer.Header().Set("Content-Type", "text/event-stream")
 		c.Writer.Header().Set("Cache-Control", "no-cache")
@@ -39,38 +39,43 @@ func Stream(a *apppkg.App) gin.HandlerFunc {
 
 		ctx := c.Request.Context()
 
-		// Determine starting point based on Last-Event-ID
-		last := time.Time{}
-		if id := c.GetHeader("Last-Event-ID"); id != "" {
-			_ = a.DB.QueryRow(ctx, `select created_at from ticket_events where id=$1`, id).Scan(&last)
-		}
+        // Determine starting point based on Last-Event-ID
+        // Use a stable resume cursor (created_at, id) to avoid dropping
+        // events that share the same timestamp as the last delivered event.
+        last := time.Time{}
+        lastID := ""
+        if id := c.GetHeader("Last-Event-ID"); id != "" {
+            _ = a.DB.QueryRow(ctx, `select created_at from ticket_events where id=$1`, id).Scan(&last)
+            lastID = id
+        }
 
-		// Helper to send all events newer than the provided time.
-		send := func(since time.Time) time.Time {
-			rows, err := a.DB.Query(ctx, `select id::text, event_type, payload, created_at from ticket_events where created_at > $1 order by created_at asc`, since)
-			if err != nil {
-				return since
-			}
-			defer rows.Close()
-			for rows.Next() {
-				var id, typ string
-				var payload []byte
-				var ts time.Time
-				if err := rows.Scan(&id, &typ, &payload, &ts); err != nil {
-					continue
-				}
-				env := Envelope{Type: typ, Data: payload}
-				b, _ := json.Marshal(env)
-				fmt.Fprintf(c.Writer, "id: %s\n", id)
-				fmt.Fprintf(c.Writer, "event: %s\n", typ)
-				fmt.Fprintf(c.Writer, "data: %s\n\n", b)
-				flusher.Flush()
-				since = ts
-			}
-			return since
-		}
+        // Helper to send all events newer than the provided cursor.
+        send := func(since time.Time, sinceID string) (time.Time, string) {
+            rows, err := a.DB.Query(ctx, `select id::text, event_type, payload, created_at from ticket_events where (created_at, id) > ($1, $2) order by created_at asc, id asc`, since, sinceID)
+            if err != nil {
+                return since, sinceID
+            }
+            defer rows.Close()
+            for rows.Next() {
+                var id, typ string
+                var payload []byte
+                var ts time.Time
+                if err := rows.Scan(&id, &typ, &payload, &ts); err != nil {
+                    continue
+                }
+                env := Envelope{Type: typ, Data: payload}
+                b, _ := json.Marshal(env)
+                fmt.Fprintf(c.Writer, "id: %s\n", id)
+                fmt.Fprintf(c.Writer, "event: %s\n", typ)
+                fmt.Fprintf(c.Writer, "data: %s\n\n", b)
+                flusher.Flush()
+                since = ts
+                sinceID = id
+            }
+            return since, sinceID
+        }
 
-		last = send(last)
+        last, lastID = send(last, lastID)
 
 		poll := time.NewTicker(time.Second)
 		heart := time.NewTicker(25 * time.Second)
@@ -81,8 +86,8 @@ func Stream(a *apppkg.App) gin.HandlerFunc {
 			select {
 			case <-ctx.Done():
 				return
-			case <-poll.C:
-				last = send(last)
+            case <-poll.C:
+                last, lastID = send(last, lastID)
 			case <-heart.C:
 				fmt.Fprint(c.Writer, ": heartbeat\n\n")
 				flusher.Flush()

--- a/cmd/api/events/events_test.go
+++ b/cmd/api/events/events_test.go
@@ -1,0 +1,150 @@
+package events
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+)
+
+// fakeRow and fakeRows provide minimal pgx interfaces for the event store.
+type fakeRow struct {
+	err  error
+	scan func(dest ...any) error
+}
+
+func (r *fakeRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	if r.scan != nil {
+		return r.scan(dest...)
+	}
+	return nil
+}
+
+type event struct {
+	id        string
+	typ       string
+	payload   []byte
+	createdAt time.Time
+}
+
+type eventRows struct {
+	idx int
+	evs []event
+}
+
+func (r *eventRows) Close()                                       {}
+func (r *eventRows) Err() error                                   { return nil }
+func (r *eventRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *eventRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *eventRows) Next() bool                                   { return r.idx < len(r.evs) }
+func (r *eventRows) Scan(dest ...any) error {
+	ev := r.evs[r.idx]
+	r.idx++
+	if len(dest) >= 4 {
+		if s, ok := dest[0].(*string); ok {
+			*s = ev.id
+		}
+		if s, ok := dest[1].(*string); ok {
+			*s = ev.typ
+		}
+		if b, ok := dest[2].(*[]byte); ok {
+			*b = ev.payload
+		}
+		if t, ok := dest[3].(*time.Time); ok {
+			*t = ev.createdAt
+		}
+	}
+	return nil
+}
+func (r *eventRows) Values() ([]any, error) { return nil, nil }
+func (r *eventRows) RawValues() [][]byte    { return nil }
+func (r *eventRows) Conn() *pgx.Conn        { return nil }
+
+type fakeEventDB struct {
+	events []event
+}
+
+func (db *fakeEventDB) add(typ, payload string) string {
+	id := uuid.New().String()
+	db.events = append(db.events, event{id: id, typ: typ, payload: []byte(payload), createdAt: time.Now()})
+	return id
+}
+
+func (db *fakeEventDB) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	since, _ := args[0].(time.Time)
+	out := []event{}
+	for _, e := range db.events {
+		if e.createdAt.After(since) {
+			out = append(out, e)
+		}
+	}
+	return &eventRows{evs: out}, nil
+}
+
+func (db *fakeEventDB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	id, _ := args[0].(string)
+	for _, e := range db.events {
+		if e.id == id {
+			return &fakeRow{scan: func(dest ...any) error {
+				if len(dest) > 0 {
+					if t, ok := dest[0].(*time.Time); ok {
+						*t = e.createdAt
+					}
+				}
+				return nil
+			}}
+		}
+	}
+	return &fakeRow{err: pgx.ErrNoRows}
+}
+
+func (db *fakeEventDB) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func TestStreamResume(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := &fakeEventDB{}
+	first := db.add("ticket_created", `{"id":"1"}`)
+	time.Sleep(time.Millisecond)
+	second := db.add("ticket_updated", `{"id":"1"}`)
+
+	a := apppkg.NewApp(apppkg.Config{Env: "test", TestBypassAuth: true}, db, nil, nil, nil)
+	a.R.GET("/events", authpkg.Middleware(a), Stream(a))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	req.Header.Set("Last-Event-ID", first)
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		a.R.ServeHTTP(rr, req)
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rr.Body.String()
+	if strings.Contains(body, first) {
+		t.Fatalf("stream included old event: %s", body)
+	}
+	if !strings.Contains(body, second) {
+		t.Fatalf("stream missing new event: %s", body)
+	}
+}

--- a/cmd/api/events/events_test.go
+++ b/cmd/api/events/events_test.go
@@ -1,20 +1,21 @@
 package events
 
 import (
-	"context"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
-	"time"
+    "context"
+    "net/http"
+    "net/http/httptest"
+    "sort"
+    "strings"
+    "testing"
+    "time"
 
-	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
+    "github.com/gin-gonic/gin"
+    "github.com/google/uuid"
+    "github.com/jackc/pgx/v5"
+    "github.com/jackc/pgx/v5/pgconn"
 
-	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
-	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+    apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+    authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
 )
 
 // fakeRow and fakeRows provide minimal pgx interfaces for the event store.
@@ -84,14 +85,22 @@ func (db *fakeEventDB) add(typ, payload string) string {
 }
 
 func (db *fakeEventDB) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
-	since, _ := args[0].(time.Time)
-	out := []event{}
-	for _, e := range db.events {
-		if e.createdAt.After(since) {
-			out = append(out, e)
-		}
-	}
-	return &eventRows{evs: out}, nil
+    since, _ := args[0].(time.Time)
+    sinceID, _ := args[1].(string)
+    out := []event{}
+    for _, e := range db.events {
+        if e.createdAt.After(since) || (e.createdAt.Equal(since) && e.id > sinceID) {
+            out = append(out, e)
+        }
+    }
+    // Ensure stable ordering to match ORDER BY created_at ASC, id ASC
+    sort.Slice(out, func(i, j int) bool {
+        if out[i].createdAt.Equal(out[j].createdAt) {
+            return out[i].id < out[j].id
+        }
+        return out[i].createdAt.Before(out[j].createdAt)
+    })
+    return &eventRows{evs: out}, nil
 }
 
 func (db *fakeEventDB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
@@ -147,4 +156,43 @@ func TestStreamResume(t *testing.T) {
 	if !strings.Contains(body, second) {
 		t.Fatalf("stream missing new event: %s", body)
 	}
+}
+
+func TestStreamResume_SameTimestamp(t *testing.T) {
+    gin.SetMode(gin.TestMode)
+    db := &fakeEventDB{}
+    ts := time.Now()
+    // Manually craft two events with identical timestamps
+    firstID := uuid.New().String()
+    secondID := uuid.New().String()
+    db.events = append(db.events,
+        event{id: firstID, typ: "ticket_created", payload: []byte(`{"id":"1"}`), createdAt: ts},
+        event{id: secondID, typ: "ticket_updated", payload: []byte(`{"id":"1"}`), createdAt: ts},
+    )
+
+    a := apppkg.NewApp(apppkg.Config{Env: "test", TestBypassAuth: true}, db, nil, nil, nil)
+    a.R.GET("/events", authpkg.Middleware(a), Stream(a))
+
+    rr := httptest.NewRecorder()
+    req := httptest.NewRequest(http.MethodGet, "/events", nil)
+    req.Header.Set("Last-Event-ID", firstID)
+    ctx, cancel := context.WithCancel(context.Background())
+    req = req.WithContext(ctx)
+
+    done := make(chan struct{})
+    go func() {
+        a.R.ServeHTTP(rr, req)
+        close(done)
+    }()
+    time.Sleep(20 * time.Millisecond)
+    cancel()
+    <-done
+
+    body := rr.Body.String()
+    if strings.Contains(body, firstID) {
+        t.Fatalf("stream included old event: %s", body)
+    }
+    if !strings.Contains(body, secondID) {
+        t.Fatalf("stream missing new equal-timestamp event: %s", body)
+    }
 }

--- a/cmd/api/tickets/assign.go
+++ b/cmd/api/tickets/assign.go
@@ -7,7 +7,7 @@ import (
 
 	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
 	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
-	handlers "github.com/mark3748/helpdesk-go/cmd/api/handlers"
+	eventspkg "github.com/mark3748/helpdesk-go/cmd/api/events"
 )
 
 // Assign changes the assignee of a ticket and emits a ticket_updated event.
@@ -57,7 +57,7 @@ func Assign(a *apppkg.App) gin.HandlerFunc {
 		}
 		t.Number = number
 		t.AssigneeID = assignee
-		handlers.PublishEvent(c.Request.Context(), a.Q, handlers.Event{Type: "ticket_updated", Data: map[string]any{"id": t.ID}})
+		eventspkg.Emit(c.Request.Context(), a.DB, t.ID, "ticket_updated", map[string]any{"id": t.ID})
 		c.JSON(http.StatusOK, t)
 	}
 }

--- a/cmd/api/tickets/tickets.go
+++ b/cmd/api/tickets/tickets.go
@@ -15,7 +15,7 @@ import (
 
 	app "github.com/mark3748/helpdesk-go/cmd/api/app"
 	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
-	handlers "github.com/mark3748/helpdesk-go/cmd/api/handlers"
+	eventspkg "github.com/mark3748/helpdesk-go/cmd/api/events"
 	requesterspkg "github.com/mark3748/helpdesk-go/cmd/api/requesters"
 )
 
@@ -173,6 +173,7 @@ returning id::text, number, title, status, assignee_id::text, priority`
 			} else {
 				t.Requester = email
 			}
+			eventspkg.Emit(c.Request.Context(), a.DB, t.ID, "ticket_created", map[string]any{"id": t.ID})
 		}
 		c.JSON(http.StatusCreated, t)
 	}
@@ -403,7 +404,7 @@ func Update(a *app.App) gin.HandlerFunc {
 		t.Number = number
 		t.AssigneeID = assignee
 		if in.AssigneeID != nil {
-			handlers.PublishEvent(c.Request.Context(), a.Q, handlers.Event{Type: "ticket_updated", Data: map[string]any{"id": t.ID}})
+			eventspkg.Emit(c.Request.Context(), a.DB, t.ID, "ticket_updated", map[string]any{"id": t.ID})
 		}
 		c.JSON(http.StatusOK, t)
 	}


### PR DESCRIPTION
## Summary
- stream `ticket_events` over SSE with Last-Event-ID resume and heartbeat comments
- record ticket updates (create, comment, assign, attach) into `ticket_events`
- cover reconnection logic with Last-Event-ID test

## Testing
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b87ea8665883229271a83f99eb6ef8