### PR TITLE
api: add liveness and readiness checks

### DIFF
--- a/cmd/api/handlers/settings.go
+++ b/cmd/api/handlers/settings.go
@@ -83,6 +83,17 @@ func SaveMailSettings(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"ok": true})
 }
 
+// MailSettings returns the current mail configuration.
+func MailSettings() map[string]string {
+	mu.RLock()
+	defer mu.RUnlock()
+	out := make(map[string]string, len(cfgStore.Mail))
+	for k, v := range cfgStore.Mail {
+		out[k] = v
+	}
+	return out
+}
+
 // TestConnection records a test run and returns log path and last result.
 func TestConnection(c *gin.Context) {
 	mu.Lock()

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -490,20 +490,20 @@ func (a *App) readyz(c *gin.Context) {
 		}
 	}
 
-	if ms := handlers.MailSettings(); ms != nil {
-		host := ms["host"]
-		port := ms["port"]
-		if host != "" && port != "" {
-			conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), 5*time.Second)
-			if err != nil {
-				log.Error().Err(err).Msg("readyz smtp")
-				c.JSON(500, gin.H{"error": "smtp"})
-				return
-			}
-			fmt.Fprintf(conn, "QUIT\r\n")
-			conn.Close()
-		}
-	}
+    if ms := handlers.MailSettings(); ms != nil {
+        host := ms["host"]
+        port := ms["port"]
+        if host != "" && port != "" {
+            // Basic connectivity check only; do not send SMTP commands.
+            conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), 5*time.Second)
+            if err != nil {
+                log.Error().Err(err).Msg("readyz smtp")
+                c.JSON(500, gin.H{"error": "smtp"})
+                return
+            }
+            conn.Close()
+        }
+    }
 
 	c.JSON(200, gin.H{"ok": true})
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -354,6 +355,8 @@ func main() {
 }
 
 func (a *App) routes() {
+	a.r.GET("/livez", func(c *gin.Context) { c.JSON(200, gin.H{"ok": true}) })
+	a.r.GET("/readyz", a.readyz)
 	a.r.GET("/healthz", func(c *gin.Context) { c.JSON(200, gin.H{"ok": true}) })
 	a.r.GET("/csat/:token", a.submitCSAT)
 	// API docs UI and spec
@@ -422,6 +425,61 @@ func (a *App) openapiSpec(c *gin.Context) {
 		}
 	}
 	c.JSON(404, gin.H{"error": "openapi spec not found"})
+}
+
+func (a *App) readyz(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if a.db != nil {
+		var n int
+		if err := a.db.QueryRow(ctx, "select 1").Scan(&n); err != nil {
+			log.Error().Err(err).Msg("readyz db")
+			c.JSON(500, gin.H{"error": "db"})
+			return
+		}
+	}
+
+	if a.m != nil {
+		switch s := a.m.(type) {
+		case *minio.Client:
+			ok, err := s.BucketExists(ctx, a.cfg.MinIOBucket)
+			if err != nil || !ok {
+				log.Error().Err(err).Str("bucket", a.cfg.MinIOBucket).Msg("readyz minio")
+				c.JSON(500, gin.H{"error": "object_store"})
+				return
+			}
+		case *fsObjectStore:
+			dir := s.base
+			if a.cfg.MinIOBucket != "" {
+				dir = filepath.Join(dir, a.cfg.MinIOBucket)
+			}
+			testFile := filepath.Join(dir, ".readyz")
+			if err := os.WriteFile(testFile, []byte("ok"), 0o644); err != nil {
+				log.Error().Err(err).Msg("readyz filestore")
+				c.JSON(500, gin.H{"error": "object_store"})
+				return
+			}
+			_ = os.Remove(testFile)
+		}
+	}
+
+	if ms := handlers.MailSettings(); ms != nil {
+		host := ms["host"]
+		port := ms["port"]
+		if host != "" && port != "" {
+			conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), 5*time.Second)
+			if err != nil {
+				log.Error().Err(err).Msg("readyz smtp")
+				c.JSON(500, gin.H{"error": "smtp"})
+				return
+			}
+			fmt.Fprintf(conn, "QUIT\r\n")
+			conn.Close()
+		}
+	}
+
+	c.JSON(200, gin.H{"ok": true})
 }
 
 type AuthUser struct {
@@ -609,8 +667,8 @@ func seedLocalAdmin(ctx context.Context, db *pgxpool.Pool) error {
 	if err := db.QueryRow(ctx, "insert into users (id, username, email, display_name, password_hash) values (gen_random_uuid(), 'admin', 'admin@example.com', 'Admin', $1) returning id", string(hash)).Scan(&uid); err != nil {
 		return err
 	}
-    // Grant all roles to built-in admin (super user)
-    _, _ = db.Exec(ctx, `insert into user_roles (user_id, role_id)
+	// Grant all roles to built-in admin (super user)
+	_, _ = db.Exec(ctx, `insert into user_roles (user_id, role_id)
 select $1, r.id from roles r on conflict do nothing`, uid)
 	log.Info().Str("username", "admin").Msg("seeded local admin user (dev)")
 	return nil
@@ -669,30 +727,30 @@ func (a *App) logout(c *gin.Context) {
 }
 
 func (a *App) requireRole(roles ...string) gin.HandlerFunc {
-    return func(c *gin.Context) {
-        u, ok := c.Get("user")
-        if !ok {
-            c.AbortWithStatusJSON(401, gin.H{"error": "unauthenticated"})
-            return
-        }
-        user := u.(AuthUser)
-        // Treat 'admin' as a super-user that can access any route.
-        for _, r := range user.Roles {
-            if r == "admin" {
-                c.Next()
-                return
-            }
-        }
-        for _, r := range user.Roles {
-            for _, want := range roles {
-                if r == want {
-                    c.Next()
-                    return
-                }
-            }
-        }
-        c.AbortWithStatusJSON(403, gin.H{"error": "forbidden"})
-    }
+	return func(c *gin.Context) {
+		u, ok := c.Get("user")
+		if !ok {
+			c.AbortWithStatusJSON(401, gin.H{"error": "unauthenticated"})
+			return
+		}
+		user := u.(AuthUser)
+		// Treat 'admin' as a super-user that can access any route.
+		for _, r := range user.Roles {
+			if r == "admin" {
+				c.Next()
+				return
+			}
+		}
+		for _, r := range user.Roles {
+			for _, want := range roles {
+				if r == want {
+					c.Next()
+					return
+				}
+			}
+		}
+		c.AbortWithStatusJSON(403, gin.H{"error": "forbidden"})
+	}
 }
 
 func (a *App) me(c *gin.Context) {

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -13,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	handlers "github.com/mark3748/helpdesk-go/cmd/api/handlers"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
@@ -35,6 +38,79 @@ func TestHealthz(t *testing.T) {
 	if ok, _ := body["ok"].(bool); !ok {
 		t.Fatalf("expected ok=true in body, got: %v", body)
 	}
+}
+
+func TestLivez(t *testing.T) {
+	cfg := Config{Env: "test"}
+	app := NewApp(cfg, nil, nil, nil, nil)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	app.r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}
+
+type readyzRow struct{ err error }
+
+func (r readyzRow) Scan(dest ...any) error { return r.err }
+
+type readyzDB struct{ err error }
+
+func (db readyzDB) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	return nil, nil
+}
+func (db readyzDB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	return readyzRow{err: db.err}
+}
+func (db readyzDB) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func setMail(ms map[string]string) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	b, _ := json.Marshal(ms)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(b))
+	c.Request.Header.Set("Content-Type", "application/json")
+	handlers.SaveMailSettings(c)
+}
+
+func TestReadyzFailures(t *testing.T) {
+	t.Run("db", func(t *testing.T) {
+		setMail(map[string]string{"host": "", "port": ""})
+		app := NewApp(Config{Env: "test", MinIOBucket: "b"}, readyzDB{err: errors.New("db")}, nil, nil, nil)
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		app.r.ServeHTTP(rr, req)
+		if rr.Code == http.StatusOK {
+			t.Fatalf("expected failure, got %d", rr.Code)
+		}
+	})
+
+	t.Run("object store", func(t *testing.T) {
+		setMail(map[string]string{"host": "", "port": ""})
+		app := NewApp(Config{Env: "test", MinIOBucket: "b"}, readyzDB{}, nil, &fsObjectStore{base: "/no/such"}, nil)
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		app.r.ServeHTTP(rr, req)
+		if rr.Code == http.StatusOK {
+			t.Fatalf("expected failure, got %d", rr.Code)
+		}
+	})
+
+	t.Run("smtp", func(t *testing.T) {
+		setMail(map[string]string{"host": "127.0.0.1", "port": "1"})
+		app := NewApp(Config{Env: "test", MinIOBucket: "b"}, readyzDB{}, nil, nil, nil)
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		app.r.ServeHTTP(rr, req)
+		if rr.Code == http.StatusOK {
+			t.Fatalf("expected failure, got %d", rr.Code)
+		}
+	})
 }
 
 func TestMe_BypassAuth(t *testing.T) {

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -101,45 +101,45 @@ func TestReadyzFailures(t *testing.T) {
 		}
 	})
 
-    t.Run("smtp", func(t *testing.T) {
-        setMail(map[string]string{"host": "127.0.0.1", "port": "1"})
-        app := NewApp(Config{Env: "test", MinIOBucket: "b"}, readyzDB{}, nil, nil, nil)
-        rr := httptest.NewRecorder()
-        req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
-        app.r.ServeHTTP(rr, req)
-        if rr.Code == http.StatusOK {
-            t.Fatalf("expected failure, got %d", rr.Code)
-        }
-    })
+	t.Run("smtp", func(t *testing.T) {
+		setMail(map[string]string{"host": "127.0.0.1", "port": "1"})
+		app := NewApp(Config{Env: "test", MinIOBucket: "b"}, readyzDB{}, nil, nil, nil)
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		app.r.ServeHTTP(rr, req)
+		if rr.Code == http.StatusOK {
+			t.Fatalf("expected failure, got %d", rr.Code)
+		}
+	})
 
-    t.Run("redis", func(t *testing.T) {
-        setMail(map[string]string{"host": "", "port": ""})
-        app := NewApp(Config{Env: "test", MinIOBucket: "b"}, readyzDB{}, nil, nil, nil)
-        // Override pingRedis to simulate a failing Redis
-        app.pingRedis = func(ctx context.Context) error { return errors.New("redis down") }
-        rr := httptest.NewRecorder()
-        req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
-        app.r.ServeHTTP(rr, req)
-        if rr.Code == http.StatusOK {
-            t.Fatalf("expected failure, got %d", rr.Code)
-        }
-        if !strings.Contains(rr.Body.String(), "redis") {
-            t.Fatalf("expected redis error in body, got %s", rr.Body.String())
-        }
-    })
+	t.Run("redis", func(t *testing.T) {
+		setMail(map[string]string{"host": "", "port": ""})
+		app := NewApp(Config{Env: "test", MinIOBucket: "b"}, readyzDB{}, nil, nil, nil)
+		// Override pingRedis to simulate a failing Redis
+		app.pingRedis = func(ctx context.Context) error { return errors.New("redis down") }
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		app.r.ServeHTTP(rr, req)
+		if rr.Code == http.StatusOK {
+			t.Fatalf("expected failure, got %d", rr.Code)
+		}
+		if !strings.Contains(rr.Body.String(), "redis") {
+			t.Fatalf("expected redis error in body, got %s", rr.Body.String())
+		}
+	})
 
-    t.Run("object store bucket auto-create", func(t *testing.T) {
-        setMail(map[string]string{"host": "", "port": ""})
-        dir := t.TempDir()
-        // Do not create bucket subdir; readyz should mkdir it and succeed
-        app := NewApp(Config{Env: "test", MinIOBucket: "attachments"}, readyzDB{}, nil, &fsObjectStore{base: dir}, nil)
-        rr := httptest.NewRecorder()
-        req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
-        app.r.ServeHTTP(rr, req)
-        if rr.Code != http.StatusOK {
-            t.Fatalf("expected success, got %d body=%s", rr.Code, rr.Body.String())
-        }
-    })
+	t.Run("object store bucket auto-create", func(t *testing.T) {
+		setMail(map[string]string{"host": "", "port": ""})
+		dir := t.TempDir()
+		// Do not create bucket subdir; readyz should mkdir it and succeed
+		app := NewApp(Config{Env: "test", MinIOBucket: "attachments"}, readyzDB{}, nil, &fsObjectStore{base: dir}, nil)
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		app.r.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected success, got %d body=%s", rr.Code, rr.Body.String())
+		}
+	})
 }
 
 func TestMe_BypassAuth(t *testing.T) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,8 @@ Base URL examples:
 ## Endpoints
 
 Health
+- GET `/livez` → 200 OK `{ "ok": true }`
+- GET `/readyz` → 200 OK `{ "ok": true }` | 500
 - GET `/healthz` → 200 OK `{ "ok": true }`
 
 Auth (local mode only)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -144,6 +144,21 @@ components:
           additionalProperties:
             type: string
 paths:
+  /livez:
+    get:
+      tags: [Health]
+      summary: Liveness check
+      security: []
+      responses:
+        '200': { description: OK }
+  /readyz:
+    get:
+      tags: [Health]
+      summary: Readiness check
+      security: []
+      responses:
+        '200': { description: OK }
+        '500': { description: Dependency failure }
   /healthz:
     get:
       tags: [Health]

--- a/helm/helpdesk/templates/deployment-api.yaml
+++ b/helm/helpdesk/templates/deployment-api.yaml
@@ -34,13 +34,13 @@ spec:
             {{- end }}
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10


### PR DESCRIPTION
## Summary
- add /livez and /readyz endpoints
- readiness handler validates database, object store and SMTP
- document new endpoints and update Helm probes

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8abde7ac88322b958e2608ba6cb4c