### PR TITLE
ratelimit: namespace keys per endpoint

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -237,13 +237,13 @@ func NewApp(cfg Config, db DB, keyf jwt.Keyfunc, store ObjectStore, q *redis.Cli
 	if q != nil {
 		a.pingRedis = func(ctx context.Context) error { return q.Ping(ctx).Err() }
 		if cfg.LoginRateLimit > 0 {
-			a.loginRL = rateln.New(q, cfg.LoginRateLimit, time.Minute)
+			a.loginRL = rateln.New(q, cfg.LoginRateLimit, time.Minute, "login:")
 		}
 		if cfg.TicketRateLimit > 0 {
-			a.ticketRL = rateln.New(q, cfg.TicketRateLimit, time.Minute)
+			a.ticketRL = rateln.New(q, cfg.TicketRateLimit, time.Minute, "tickets:")
 		}
 		if cfg.AttachmentRateLimit > 0 {
-			a.attRL = rateln.New(q, cfg.AttachmentRateLimit, time.Minute)
+			a.attRL = rateln.New(q, cfg.AttachmentRateLimit, time.Minute, "attachments:")
 		}
 	}
 	handlers.InitSettings(cfg.LogPath)

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -14,7 +14,7 @@ import (
 func TestMiddleware(t *testing.T) {
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	l := New(rdb, 2, time.Minute)
+	l := New(rdb, 2, time.Minute, "test:")
 	r := gin.New()
 	r.Use(l.Middleware(func(c *gin.Context) string { return "key" }))
 	r.GET("/", func(c *gin.Context) { c.String(200, "ok") })


### PR DESCRIPTION
## Summary
- parameterize rate limiter key prefix so different limiters don't share buckets
- scope login, ticket, and attachment limiters with unique prefixes

## Testing
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8ba1e635483228dcdccc3bf609adc