### PR TITLE
api: record ticket events

### DIFF
--- a/cmd/api/migrations/0006_ticket_events.sql
+++ b/cmd/api/migrations/0006_ticket_events.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+create table if not exists ticket_events (
+    id uuid primary key default gen_random_uuid(),
+    ticket_id uuid references tickets(id) on delete cascade,
+    action text not null,
+    actor_id uuid,
+    diff_json jsonb,
+    at timestamptz not null default now()
+);
+
+-- +goose Down
+drop table if exists ticket_events;


### PR DESCRIPTION
## Summary
- add migration for ticket_events table
- log ticket events on create, update, comments, attachments and watchers
- test ticket event emission

## Testing
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8ca7935b48322980ae6482959ce58