### PR TITLE
settings: extend oidc roles and add mail test endpoint

### DIFF
--- a/cmd/worker/templates/test_email.tmpl
+++ b/cmd/worker/templates/test_email.tmpl
@@ -1,0 +1,9 @@
+{{ define "test_email_subject" }}Test Email{{ end }}
+{{ define "test_email_body" }}
+Hello,
+
+This is a test email.
+
+Thanks,
+Helpdesk
+{{ end }}

--- a/web/internal/src/api.ts
+++ b/web/internal/src/api.ts
@@ -158,6 +158,28 @@ export function useSaveMailSettings() {
   });
 }
 
+export function useSaveOIDCSettings() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: Record<string, unknown>) =>
+      apiFetch('/settings/oidc', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['settings'] }),
+  });
+}
+
+export function useSendTestEmail() {
+  return useMutation({
+    mutationFn: () =>
+      apiFetch('/settings/mail/send-test', {
+        method: 'POST',
+      }),
+  });
+}
+
 export function useTestConnection() {
   const qc = useQueryClient();
   return useMutation({

--- a/web/internal/src/components/admin/MailSettings.tsx
+++ b/web/internal/src/components/admin/MailSettings.tsx
@@ -1,12 +1,13 @@
 import { useEffect } from 'react';
 import { Form, Input, Button, message } from 'antd';
-import { useSettings, useSaveMailSettings, useTestConnection } from '../../api';
+import { useSettings, useSaveMailSettings, useTestConnection, useSendTestEmail } from '../../api';
 
 export default function MailSettings() {
   const [form] = Form.useForm();
   const { data } = useSettings();
   const save = useSaveMailSettings();
   const test = useTestConnection();
+  const sendTest = useSendTestEmail();
 
   useEffect(() => {
     if ((data as any)?.mail) {
@@ -33,9 +34,21 @@ export default function MailSettings() {
           })
         }
         loading={test.isPending}
-        style={{ marginBottom: 16 }}
+        style={{ marginBottom: 16, marginRight: 8 }}
       >
         Test Connection
+      </Button>
+      <Button
+        onClick={() =>
+          sendTest.mutate(undefined, {
+            onSuccess: () => message.success('Test email queued'),
+            onError: () => message.error('Failed to queue email'),
+          })
+        }
+        loading={sendTest.isPending}
+        style={{ marginBottom: 16 }}
+      >
+        Send Test Email
       </Button>
       <Form form={form} layout="vertical" onFinish={onFinish}>
       <Form.Item label="SMTP Host" name="smtp_host">

--- a/web/internal/src/components/admin/OIDCSettings.tsx
+++ b/web/internal/src/components/admin/OIDCSettings.tsx
@@ -1,26 +1,41 @@
 import { useEffect } from 'react';
-import { Form, Input, Button, message } from 'antd';
-import { useSettings, useTestConnection } from '../../api';
-import { apiFetch } from '../../shared/api';
+import { Form, Input, Button, message, Space } from 'antd';
+import { useSettings, useTestConnection, useSaveOIDCSettings } from '../../api';
 
 export default function OIDCSettings() {
   const [form] = Form.useForm();
   const { data } = useSettings();
   const test = useTestConnection();
+  const save = useSaveOIDCSettings();
 
   useEffect(() => {
     if ((data as any)?.oidc) {
-      form.setFieldsValue((data as any).oidc);
+      const oidc = (data as any).oidc as any;
+      form.setFieldsValue({
+        ...oidc,
+        value_to_roles: oidc.value_to_roles
+          ? Object.entries(oidc.value_to_roles).map(([value, roles]: any) => ({
+              value,
+              roles: (roles as string[]).join(','),
+            }))
+          : [],
+      });
     }
   }, [data, form]);
 
-  const onFinish = async (values: any) => {
-    await apiFetch('/settings/oidc', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(values),
+  const onFinish = (values: any) => {
+    const mappings: Record<string, string[]> = {};
+    (values.value_to_roles || []).forEach((m: any) => {
+      mappings[m.value] = m.roles
+        .split(',')
+        .map((r: string) => r.trim())
+        .filter(Boolean);
     });
-    message.success('OIDC settings saved');
+    const payload = { ...values, value_to_roles: mappings };
+    save.mutate(payload, {
+      onSuccess: () => message.success('OIDC settings saved'),
+      onError: () => message.error('Failed to save'),
+    });
   };
 
   return (
@@ -46,8 +61,41 @@ export default function OIDCSettings() {
         <Form.Item label="Client ID" name="client_id">
           <Input />
         </Form.Item>
+        <Form.Item label="Role Claim Path" name="claim_path">
+          <Input />
+        </Form.Item>
+        <Form.List name="value_to_roles">
+          {(fields, { add, remove }) => (
+            <>
+              {fields.map(({ key, name, ...restField }) => (
+                <Space key={key} align="baseline" style={{ marginBottom: 8 }}>
+                  <Form.Item
+                    {...restField}
+                    name={[name, 'value']}
+                    rules={[{ required: true }]}
+                  >
+                    <Input placeholder="Claim Value" />
+                  </Form.Item>
+                  <Form.Item
+                    {...restField}
+                    name={[name, 'roles']}
+                    rules={[{ required: true }]}
+                  >
+                    <Input placeholder="Roles (comma separated)" />
+                  </Form.Item>
+                  <Button onClick={() => remove(name)}>Remove</Button>
+                </Space>
+              ))}
+              <Form.Item>
+                <Button type="dashed" onClick={() => add()}>
+                  Add Mapping
+                </Button>
+              </Form.Item>
+            </>
+          )}
+        </Form.List>
         <Form.Item>
-          <Button type="primary" htmlType="submit">
+          <Button type="primary" htmlType="submit" loading={save.isPending}>
             Save
           </Button>
         </Form.Item>


### PR DESCRIPTION
## Summary
- support OIDC role mappings with claim path and value-to-roles
- add test email endpoint and queue dispatch
- expose hooks and UI for new settings and mail test

## Testing
- `npm test --prefix web/internal` *(fails: Missing script: "test")*
- `npx eslint src/api.ts src/components/admin/OIDCSettings.tsx src/components/admin/MailSettings.tsx`
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8f34f19f88322b5b9aab0a5a3a181