### PR TITLE
fix: restore watcher persistence and tests

### DIFF
--- a/cmd/api/watchers/watchers.go
+++ b/cmd/api/watchers/watchers.go
@@ -4,11 +4,84 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+
 	app "github.com/mark3748/helpdesk-go/cmd/api/app"
+	auth "github.com/mark3748/helpdesk-go/cmd/api/auth"
+	"github.com/mark3748/helpdesk-go/cmd/api/events"
 )
 
-func List(a *app.App) gin.HandlerFunc { return func(c *gin.Context) { c.JSON(http.StatusOK, []any{}) } }
-func Add(a *app.App) gin.HandlerFunc  { return func(c *gin.Context) { c.Status(http.StatusCreated) } }
+type watcherReq struct {
+	UserID string `json:"user_id" binding:"required"`
+}
+
+// List returns watcher IDs for the specified ticket.
+func List(a *app.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if a.DB == nil {
+			c.JSON(http.StatusOK, []string{})
+			return
+		}
+		ticketID := c.Param("id")
+		ctx := c.Request.Context()
+		rows, err := a.DB.Query(ctx, `select user_id from ticket_watchers where ticket_id=$1`, ticketID)
+		if err != nil {
+			app.AbortError(c, http.StatusInternalServerError, "db_query_failed", "database query failed", nil)
+			return
+		}
+		defer rows.Close()
+		out := []string{}
+		for rows.Next() {
+			var uid string
+			if err := rows.Scan(&uid); err == nil {
+				out = append(out, uid)
+			}
+		}
+		c.JSON(http.StatusOK, out)
+	}
+}
+
+// Add inserts a watcher for the ticket.
+func Add(a *app.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var in watcherReq
+		if err := c.ShouldBindJSON(&in); err != nil {
+			app.AbortError(c, http.StatusBadRequest, "invalid_body", "invalid request body", map[string]string{"user_id": "required"})
+			return
+		}
+		if a.DB != nil {
+			ctx := c.Request.Context()
+			ticketID := c.Param("id")
+			if _, err := a.DB.Exec(ctx, `insert into ticket_watchers (ticket_id, user_id) values ($1,$2) on conflict do nothing`, ticketID, in.UserID); err != nil {
+				app.AbortError(c, http.StatusInternalServerError, "db_exec_failed", "database exec failed", nil)
+				return
+			}
+			if v, ok := c.Get("user"); ok {
+				if u, ok := v.(auth.AuthUser); ok {
+					events.Emit(ctx, a.DB, ticketID, "watcher_add", gin.H{"user_id": in.UserID, "actor_id": u.ID})
+				}
+			}
+		}
+		c.Status(http.StatusCreated)
+	}
+}
+
+// Remove deletes a watcher from the ticket.
 func Remove(a *app.App) gin.HandlerFunc {
-	return func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) }
+	return func(c *gin.Context) {
+		if a.DB != nil {
+			ctx := c.Request.Context()
+			ticketID := c.Param("id")
+			watcherID := c.Param("uid")
+			if _, err := a.DB.Exec(ctx, `delete from ticket_watchers where ticket_id=$1 and user_id=$2`, ticketID, watcherID); err != nil {
+				app.AbortError(c, http.StatusInternalServerError, "db_exec_failed", "database exec failed", nil)
+				return
+			}
+			if v, ok := c.Get("user"); ok {
+				if u, ok := v.(auth.AuthUser); ok {
+					events.Emit(ctx, a.DB, ticketID, "watcher_remove", gin.H{"user_id": watcherID, "actor_id": u.ID})
+				}
+			}
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	}
 }

--- a/cmd/api/watchers/watchers_test.go
+++ b/cmd/api/watchers/watchers_test.go
@@ -1,42 +1,145 @@
 package watchers
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
 	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
 )
 
+type fakeDB struct{ watchers map[string]map[string]bool }
+
+func (db *fakeDB) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	ticketID := args[0].(string)
+	f := &fakeRows{}
+	if m, ok := db.watchers[ticketID]; ok {
+		for uid := range m {
+			f.list = append(f.list, uid)
+		}
+	}
+	return f, nil
+}
+
+func (db *fakeDB) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row { return &fakeRow{} }
+
+func (db *fakeDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	s := strings.ToLower(sql)
+	if !strings.Contains(s, "ticket_watchers") {
+		return pgconn.CommandTag{}, nil
+	}
+	ticketID := args[0].(string)
+	userID := args[1].(string)
+	if db.watchers == nil {
+		db.watchers = map[string]map[string]bool{}
+	}
+	if _, ok := db.watchers[ticketID]; !ok {
+		db.watchers[ticketID] = map[string]bool{}
+	}
+	if strings.HasPrefix(s, "insert") {
+		db.watchers[ticketID][userID] = true
+	} else {
+		delete(db.watchers[ticketID], userID)
+	}
+	return pgconn.CommandTag{}, nil
+}
+
+type fakeRows struct {
+	list []string
+	i    int
+}
+
+func (r *fakeRows) Close()                                       {}
+func (r *fakeRows) Err() error                                   { return nil }
+func (r *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeRows) RawValues() [][]byte                          { return nil }
+func (r *fakeRows) Values() ([]any, error)                       { return nil, nil }
+func (r *fakeRows) Conn() *pgx.Conn                              { return nil }
+func (r *fakeRows) Next() bool {
+	if r.i >= len(r.list) {
+		return false
+	}
+	r.i++
+	return true
+}
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.i == 0 || r.i > len(r.list) {
+		return nil
+	}
+	if p, ok := dest[0].(*string); ok {
+		*p = r.list[r.i-1]
+	}
+	return nil
+}
+
+type fakeRow struct{}
+
+func (r *fakeRow) Scan(dest ...any) error { return pgx.ErrNoRows }
+
 func TestWatcherHandlers(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	db := &fakeDB{}
 	cfg := apppkg.Config{Env: "test", TestBypassAuth: true}
-	a := apppkg.NewApp(cfg, nil, nil, nil, nil)
+	a := apppkg.NewApp(cfg, db, nil, nil, nil)
 	a.R.GET("/tickets/:id/watchers", authpkg.Middleware(a), List(a))
 	a.R.POST("/tickets/:id/watchers", authpkg.Middleware(a), Add(a))
 	a.R.DELETE("/tickets/:id/watchers/:uid", authpkg.Middleware(a), Remove(a))
 
-	tests := []struct {
-		name   string
-		method string
-		url    string
-		want   int
-	}{
-		{"list", http.MethodGet, "/tickets/1/watchers", http.StatusOK},
-		{"add", http.MethodPost, "/tickets/1/watchers", http.StatusCreated},
-		{"remove", http.MethodDelete, "/tickets/1/watchers/1", http.StatusOK},
+	// Add watcher
+	body := bytes.NewBufferString(`{"user_id":"u1"}`)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/tickets/1/watchers", body)
+	req.Header.Set("Content-Type", "application/json")
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rr.Code)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rr := httptest.NewRecorder()
-			req := httptest.NewRequest(tt.method, tt.url, nil)
-			a.R.ServeHTTP(rr, req)
-			if rr.Code != tt.want {
-				t.Fatalf("expected %d, got %d", tt.want, rr.Code)
-			}
-		})
+
+	// List should return inserted watcher
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/tickets/1/watchers", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var out []string
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || out[0] != "u1" {
+		t.Fatalf("expected [u1], got %v", out)
+	}
+
+	// Remove watcher
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodDelete, "/tickets/1/watchers/u1", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	// List should now be empty
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/tickets/1/watchers", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	out = nil
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected empty, got %v", out)
 	}
 }


### PR DESCRIPTION
## Summary
- reimplement watcher handlers to persist and query `ticket_watchers` records
- emit ticket events when adding or removing watchers
- add unit tests exercising watcher add/list/remove flows with a fake DB

## Testing
- `go test ./...`
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9049ab5208322a079d048e8c0bd28