### PR TITLE
Standardized rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ API (cmd/api):
 - `OPENAPI_SPEC_PATH`: optional path to the OpenAPI spec for serving `/openapi.yaml` in local dev (default packaged in Docker at `/opt/helpdesk/docs/openapi.yaml`).
 - `LOG_PATH`: directory for API log output (default system temp dir, e.g. `/tmp`). Falls back to stdout if unwritable.
 - `RATE_LIMIT_LOGIN`: max login/logout requests per minute per IP (default unlimited).
+- `rate_limit_rejections_total{route=...}`: Prometheus counter exported by the API indicating the number of requests rejected by rate limiting for a given route label (e.g., `login`, `tickets_create`, `attachments_presign`).
 - `RATE_LIMIT_TICKETS`: max ticket creation requests per minute per user.
 - `RATE_LIMIT_ATTACHMENTS`: max attachment upload/download requests per minute per user.
 

--- a/cmd/api/main_rl_test.go
+++ b/cmd/api/main_rl_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "testing"
+    "time"
+
+    "github.com/alicebob/miniredis/v2"
+    "github.com/gin-gonic/gin"
+    "github.com/prometheus/client_golang/prometheus/testutil"
+    "github.com/redis/go-redis/v9"
+    rateln "github.com/mark3748/helpdesk-go/internal/ratelimit"
+)
+
+// Test that rlMiddleware rejects over-limit requests and increments the metric.
+func TestRLMiddleware_IncrementsCounter(t *testing.T) {
+    t.Setenv("ENV", "test")
+    mr := miniredis.RunT(t)
+    rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+    limiter := rateln.New(rdb, 1, time.Minute, "test:")
+
+    app := &App{cfg: Config{Env: "test"}, r: gin.New()}
+    app.r.GET("/limited", app.rlMiddleware(limiter, func(c *gin.Context) string { return c.ClientIP() }, "test"), func(c *gin.Context) {
+        c.String(200, "ok")
+    })
+
+    // First request should pass
+    rr := httptest.NewRecorder()
+    req := httptest.NewRequest(http.MethodGet, "/limited", nil)
+    req.RemoteAddr = "1.2.3.4:1234"
+    app.r.ServeHTTP(rr, req)
+    if rr.Code != http.StatusOK {
+        t.Fatalf("expected 200, got %d", rr.Code)
+    }
+
+    // Second request should be rate limited and increment the counter
+    rr = httptest.NewRecorder()
+    req = httptest.NewRequest(http.MethodGet, "/limited", nil)
+    req.RemoteAddr = "1.2.3.4:1234"
+    app.r.ServeHTTP(rr, req)
+    if rr.Code != http.StatusTooManyRequests {
+        t.Fatalf("expected 429, got %d", rr.Code)
+    }
+
+    // Validate the counter incremented for the route label
+    got := testutil.ToFloat64(rlRejects.WithLabelValues("test"))
+    if got < 1 {
+        t.Fatalf("expected rate_limit_rejections_total >= 1, got %v", got)
+    }
+}
+

--- a/docs/plan-medium-prs.md
+++ b/docs/plan-medium-prs.md
@@ -1,0 +1,62 @@
+## Medium Priority Implementation Plan (PR Stubs)
+
+Branch: `medium-priority-fixes`
+
+This document outlines small, reviewable PRs to complete the Medium items in `docs/pending-issues.md`. Each PR lists scope, files, tests, and config notes.
+
+### PR1 – Rate limiting standardization
+- Scope: Ensure Redis-backed limiter is used for login, ticket create, and attachment flows.
+- Files:
+  - `cmd/api/main.go` – wrap routes with `internal/ratelimit` middleware and add rejection counter.
+  - `cmd/api/app/middleware.go` (if needed) – metrics helper.
+- Tests:
+  - `cmd/api/main_test.go` and/or dedicated handler tests to assert 429 behavior and counter increments.
+- Config:
+  - `RATE_LIMIT_LOGIN`, `RATE_LIMIT_TICKETS`, `RATE_LIMIT_ATTACHMENTS`.
+
+### PR2 – Context timeouts (DB)
+- Scope: Introduce `DB_TIMEOUT_MS` and wrap DB calls with `context.WithTimeout`.
+- Files: modular handlers under `cmd/api/*`, and helpers in `cmd/api/main.go`.
+- Tests: simulate slow DB with context deadline exceeded; expect 504/500 mapping.
+
+### PR3 – Timeouts (Redis/MinIO) + upload key validation
+- Scope: Add `REDIS_TIMEOUT_MS`, `OBJECTSTORE_TIMEOUT_MS`; enforce UUID object key on `/attachments/upload/:objectKey`.
+- Files: `cmd/api/attachments`, `cmd/api/main.go` queue/object store calls.
+- Tests: invalid key returns 400; timeout soft-fail behavior (logged, request proceeds where safe).
+
+### PR4 – JWKS hardening
+- Scope: Backoff refresh with jitter, alg/kid validation, metrics, readyz dependency.
+- Files: keyfunc wiring in `cmd/api/main.go` or extracted helper in `cmd/api/auth`.
+- Tests: invalid alg/kid, skew, audience; readyz fails without cache.
+
+### PR5 – Reproducible Swagger UI
+- Scope: Vendor Swagger UI into `docker/swagger/` and COPY in `Dockerfile.api`.
+- Files: `docker/swagger/*`, `Dockerfile.api`.
+- Tests: CI build; `/api/docs` serves UI offline.
+
+### PR6 – Multi-arch Buildx CI
+- Scope: Release workflow builds `linux/amd64,linux/arm64`.
+- Files: `.github/workflows/release.yml` (and `ci.yml` if needed), `Dockerfile.*` `--platform` args.
+- Tests: manifests present; push on tag.
+
+### PR7 – Observability counters
+- Scope: Add counters for tickets, auth failures, rate-limit rejections, attachments.
+- Files: `cmd/api/metrics` collectors; increments at handlers.
+- Tests: unit tests using a Prometheus test registry.
+
+### PR8 – CORS tightening
+- Scope: Restrict `Access-Control-Allow-Headers`, ensure `Vary: Origin`, docs.
+- Files: `cmd/api/main.go`, `README.md`/`docs/api.md`.
+- Tests: OPTIONS preflight allowed vs blocked.
+
+### PR9 – SLA tests expansion
+- Scope: Holidays and business-hours edge cases.
+- Files: `internal/sla/*_test.go`.
+- Tests: table-driven scenarios for calendars.
+
+---
+
+General test guidance:
+- Use `TEST_BYPASS_AUTH=true` for handler tests unless the test targets JWT behavior.
+- Prefer table-driven tests and fakes for DB/object store; Redis can be a running service in integration tests via `docker-compose.yml`.
+

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect


### PR DESCRIPTION
This pull request standardizes rate limiting across key API endpoints and introduces observability improvements by adding Prometheus metrics for rate limit rejections. It ensures that all relevant routes use a Redis-backed rate limiter, increments a new `rate_limit_rejections_total` metric on rejection, and includes a dedicated test to verify both rate limiting and metric behavior. Documentation and planning files are updated to reflect these changes and outline the broader implementation plan.

**Rate limiting standardization and observability:**

* Introduced a Prometheus counter `rate_limit_rejections_total{route=...}` to track rejected requests due to rate limiting, with documentation added in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R205) [[2]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afR97-R107)
* Refactored API route definitions in `cmd/api/main.go` to wrap login, ticket creation, and attachment endpoints with a new `rlMiddleware` that increments the rejection counter and standardizes limiter usage. [[1]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afR356-R372) [[2]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL539-R570) [[3]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL582-R615) [[4]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL595-R636)
* Added a test (`cmd/api/main_rl_test.go`) to verify that exceeding rate limits returns HTTP 429 and increments the Prometheus counter as expected.

**Documentation and planning updates:**

* Updated `docs/pending-issues.md` and added `docs/plan-medium-prs.md` to track the medium-priority implementation plan, including this PR's checklist and context for future work. [[1]](diffhunk://#diff-24df6a358466eb72a8873f7674e6ebb233d72d5cb5337dc6c1507ee8d86f5788R33-R87) [[2]](diffhunk://#diff-3acaa87c8c8e23cbcdb28a9ac329c11201deca6fa6b0490698a9a836605a5980R1-R62)

**Dependency management:**

* Added `github.com/davecgh/go-spew` as an indirect dependency in `go.mod`.…ter rate_limit_rejections_total.

   - Applied to login/logout, ticket create, and attachments routes.
   - Added unit test cmd/api/main_rl_test.go exercising 429 path and metric increment.
   - README updated to document the new metric.
   - docs/pending-issues.md updated to check off PR1.