### PR TITLE
PR3: Redis/ObjectStore timeouts + upload key validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ API (cmd/api):
 - `ADMIN_PASSWORD`: initial admin password in dev local-auth mode.
 - `FILESTORE_PATH`: local path for attachments (filesystem store).
 - `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_BUCKET`, `MINIO_USE_SSL`: S3/MinIO settings.
+- `REDIS_TIMEOUT_MS`: per-call Redis timeout in milliseconds (default 2000). Applies to readiness ping and queue operations.
+- `OBJECTSTORE_TIMEOUT_MS`: per-call object store timeout in milliseconds (default 10000). Applies to MinIO/S3 presign/put/stat and filesystem operations.
 - `ALLOWED_ORIGINS`: comma-separated origins allowed for cross-origin requests (default none).
 - `TEST_BYPASS_AUTH`: set `true` in tests to bypass JWT and inject a test user.
 - `OPENAPI_SPEC_PATH`: optional path to the OpenAPI spec for serving `/openapi.yaml` in local dev (default packaged in Docker at `/opt/helpdesk/docs/openapi.yaml`).

--- a/cmd/api/attachments/attachments_upload_test.go
+++ b/cmd/api/attachments/attachments_upload_test.go
@@ -1,0 +1,48 @@
+package attachments
+
+import (
+    "bytes"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+    "github.com/gin-gonic/gin"
+    apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+)
+
+func TestUploadObject_InvalidKey(t *testing.T) {
+    gin.SetMode(gin.TestMode)
+    dir := t.TempDir()
+    cfg := apppkg.Config{Env: "test", TestBypassAuth: true, MinIOBucket: "attachments", ObjectStoreTimeoutMS: 500}
+    a := apppkg.NewApp(cfg, nil, nil, &apppkg.FsObjectStore{Base: dir}, nil)
+
+    h := UploadObject(a)
+    rr := httptest.NewRecorder()
+    c, _ := gin.CreateTestContext(rr)
+    req := httptest.NewRequest(http.MethodPut, "/attachments/upload/not-a-uuid", bytes.NewReader([]byte("hello")))
+    c.Request = req
+    c.Params = gin.Params{{Key: "objectKey", Value: "not-a-uuid"}}
+    h(c)
+    if rr.Code != http.StatusBadRequest {
+        t.Fatalf("expected 400, got %d", rr.Code)
+    }
+}
+
+func TestUploadObject_Filesystem_Success(t *testing.T) {
+    gin.SetMode(gin.TestMode)
+    dir := t.TempDir()
+    cfg := apppkg.Config{Env: "test", TestBypassAuth: true, MinIOBucket: "attachments", ObjectStoreTimeoutMS: 500}
+    a := apppkg.NewApp(cfg, nil, nil, &apppkg.FsObjectStore{Base: dir}, nil)
+
+    key := "123e4567-e89b-12d3-a456-426614174000"
+    h := UploadObject(a)
+    rr := httptest.NewRecorder()
+    c, _ := gin.CreateTestContext(rr)
+    req := httptest.NewRequest(http.MethodPut, "/attachments/upload/"+key, bytes.NewReader([]byte("hello")))
+    req.Header.Set("Content-Type", "text/plain")
+    c.Request = req
+    c.Params = gin.Params{{Key: "objectKey", Value: key}}
+    h(c)
+    if rr.Code != http.StatusOK {
+        t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+    }
+}

--- a/cmd/api/main_redis_timeout_test.go
+++ b/cmd/api/main_redis_timeout_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+    "context"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+    "time"
+)
+
+// Test that readyz respects REDIS_TIMEOUT_MS and returns quickly on ping timeouts.
+func TestReadyz_RedisTimeoutSoftFail(t *testing.T) {
+    t.Setenv("ENV", "test")
+    t.Setenv("DB_TIMEOUT_MS", "0")
+    t.Setenv("REDIS_TIMEOUT_MS", "20")
+    app := NewApp(getConfig(), readyzDB{}, nil, nil, nil)
+    // Override pingRedis to simulate a slow Redis.
+    app.pingRedis = func(ctx context.Context) error {
+        // Sleep longer than REDIS_TIMEOUT_MS so the derived context cancels first.
+        select {
+        case <-time.After(200 * time.Millisecond):
+        case <-ctx.Done():
+        }
+        return ctx.Err()
+    }
+    rr := httptest.NewRecorder()
+    req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+    start := time.Now()
+    app.r.ServeHTTP(rr, req)
+    dur := time.Since(start)
+    if rr.Code == http.StatusOK {
+        t.Fatalf("expected failure due to redis timeout, got %d", rr.Code)
+    }
+    if dur > 500*time.Millisecond {
+        t.Fatalf("readyz took too long: %v", dur)
+    }
+}

--- a/docs/pending-issues.md
+++ b/docs/pending-issues.md
@@ -46,11 +46,11 @@ Tracking for the current branch `medium-priority-fixes`. See detailed stubs in `
   - [x] Wrap DB calls in handlers with `context.WithTimeout` via `a.dbCtx(c)` helper
   - [x] Tests: simulated slow DB returns failure (readyz) using a slow DB stub
 
-- [ ] PR3 – Timeouts (phase 2: Redis/MinIO) + upload key validation
-  - [ ] Add `REDIS_TIMEOUT_MS` (2000) and `OBJECTSTORE_TIMEOUT_MS` (10000)
-  - [ ] Apply to queue ops, limiter ping, presign/put/stat
-  - [ ] Validate `/attachments/upload/:objectKey` requires UUID (return 400 otherwise)
-  - [ ] Tests: Redis timeouts soft‑fail behavior; filesystem upload success + invalid key 400
+- [x] PR3 – Timeouts (phase 2: Redis/MinIO) + upload key validation
+  - [x] Add `REDIS_TIMEOUT_MS` (2000) and `OBJECTSTORE_TIMEOUT_MS` (10000)
+  - [x] Apply to queue ops, limiter ping, presign/put/stat
+  - [x] Validate `/attachments/upload/:objectKey` requires UUID (return 400 otherwise)
+  - [x] Tests: Redis timeouts soft‑fail behavior; filesystem upload success + invalid key 400
 
 - [ ] PR4 – JWKS hardening
   - [ ] Replace fixed ticker with jittered exponential backoff refresh; keep last‑good cache

--- a/helm/helpdesk/values.yaml
+++ b/helm/helpdesk/values.yaml
@@ -68,6 +68,9 @@ env:
   # External services (set to your endpoints)
   DATABASE_URL: "postgres://user:pass@postgres:5432/helpdesk?sslmode=disable"
   REDIS_ADDR: "redis:6379"
+  # Timeouts (ms)
+  REDIS_TIMEOUT_MS: "2000"
+  OBJECTSTORE_TIMEOUT_MS: "10000"
   # API auth (optional)
   AUTH_MODE: "oidc"
   AUTH_LOCAL_SECRET: ""


### PR DESCRIPTION
This PR implements Medium PR3 from docs/pending-issues.md:

- Add REDIS_TIMEOUT_MS (default 2000) and OBJECTSTORE_TIMEOUT_MS (default 10000).
- Apply Redis timeout to:
  - readyz Redis ping
  - queue operations in enqueueEmail (RPush/LLen) and event publish
  - Redis client Dial/Read/Write timeouts via go-redis options
- Apply ObjectStore timeout to:
  - MinIO/S3 presign (PUT/GET)
  - PutObject and StatObject for finalize and filesystem uploads
  - readyz MinIO bucket check
- Enforce UUID for internal filesystem upload key at `/attachments/upload/:objectKey` (returns 400 otherwise).

Tests
- cmd/api/main_redis_timeout_test.go: readyz returns quickly on simulated Redis timeout (soft-fail of ping path, no hangs).
- cmd/api/attachments/attachments_upload_test.go:
  - invalid non-UUID key -> 400
  - filesystem upload with UUID key -> 200

Config
- REDIS_TIMEOUT_MS: default 2000 ms
- OBJECTSTORE_TIMEOUT_MS: default 10000 ms

Notes
- Modular handlers now receive `ObjectStoreTimeoutMS` through `app.App` and use it via `App.ObjCtx(...)` when performing presign/put/stat.
- No behavior change when timeouts are unset or <= 0.
