### PR TITLE
sla: expand table-driven tests

### DIFF
--- a/internal/sla/load_calendar_test.go
+++ b/internal/sla/load_calendar_test.go
@@ -1,12 +1,12 @@
 package sla
 
 import (
-    "context"
-    "testing"
-    "time"
+	"context"
+	"testing"
+	"time"
 
-    "github.com/jackc/pgx/v5"
-    "github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 type rowFunc func(dest ...any) error
@@ -16,80 +16,112 @@ type fakeRow struct{ f rowFunc }
 func (r fakeRow) Scan(dest ...any) error { return r.f(dest...) }
 
 type fakeRows struct {
-    data [][]any
-    i    int
+	data [][]any
+	i    int
 }
 
-func (r *fakeRows) Close()                           {}
-func (r *fakeRows) Err() error                       { return nil }
-func (r *fakeRows) CommandTag() pgconn.CommandTag    { return pgconn.CommandTag{} }
+func (r *fakeRows) Close()                                       {}
+func (r *fakeRows) Err() error                                   { return nil }
+func (r *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
 func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
-func (r *fakeRows) Next() bool                       { return r.i < len(r.data) }
-func (r *fakeRows) Values() ([]any, error)           { return nil, nil }
-func (r *fakeRows) RawValues() [][]byte              { return nil }
-func (r *fakeRows) Conn() *pgx.Conn                  { return nil }
+func (r *fakeRows) Next() bool                                   { return r.i < len(r.data) }
+func (r *fakeRows) Values() ([]any, error)                       { return nil, nil }
+func (r *fakeRows) RawValues() [][]byte                          { return nil }
+func (r *fakeRows) Conn() *pgx.Conn                              { return nil }
 func (r *fakeRows) Scan(dest ...any) error {
-    row := r.data[r.i]
-    r.i++
-    for i := range dest {
-        switch d := dest[i].(type) {
-        case *int:
-            *d = row[i].(int)
-        case *time.Time:
-            *d = row[i].(time.Time)
-        }
-    }
-    return nil
+	row := r.data[r.i]
+	r.i++
+	for i := range dest {
+		switch d := dest[i].(type) {
+		case *int:
+			*d = row[i].(int)
+		case *time.Time:
+			*d = row[i].(time.Time)
+		}
+	}
+	return nil
 }
 
-type fakeDB struct{
-    tz string
-    hours [][]any
-    holidays [][]any
+type fakeDB struct {
+	tz       string
+	hours    [][]any
+	holidays [][]any
 }
 
 func (db fakeDB) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
-    if len(db.hours) > 0 && sql == "select dow, start_sec, end_sec from business_hours where calendar_id=$1" {
-        return &fakeRows{data: db.hours}, nil
-    }
-    if len(db.holidays) > 0 && sql == "select date from holidays where calendar_id=$1" {
-        return &fakeRows{data: db.holidays}, nil
-    }
-    return &fakeRows{}, nil
+	if len(db.hours) > 0 && sql == "select dow, start_sec, end_sec from business_hours where calendar_id=$1" {
+		return &fakeRows{data: db.hours}, nil
+	}
+	if len(db.holidays) > 0 && sql == "select date from holidays where calendar_id=$1" {
+		return &fakeRows{data: db.holidays}, nil
+	}
+	return &fakeRows{}, nil
 }
 func (db fakeDB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
-    if sql == "select tz from calendars where id=$1" {
-        return fakeRow{f: func(dest ...any) error {
-            *(dest[0].(*string)) = db.tz
-            return nil
-        }}
-    }
-    return fakeRow{f: func(dest ...any) error { return nil }}
+	if sql == "select tz from calendars where id=$1" {
+		return fakeRow{f: func(dest ...any) error {
+			*(dest[0].(*string)) = db.tz
+			return nil
+		}}
+	}
+	return fakeRow{f: func(dest ...any) error { return nil }}
 }
 
-func TestLoadCalendar_LoadsHoursAndHolidays(t *testing.T) {
-    loc := "America/New_York"
-    // hours: Mon 9-17
-    hours := [][]any{{int(time.Monday), 9*3600, 17*3600}}
-    // holiday: 2024-07-04
-    hday := time.Date(2024, 7, 4, 0, 0, 0, 0, time.UTC)
-    holidays := [][]any{{hday}}
-    db := fakeDB{tz: loc, hours: hours, holidays: holidays}
+func TestLoadCalendar(t *testing.T) {
+	loc := "America/New_York"
+	cases := []struct {
+		name     string
+		db       fakeDB
+		validate func(t *testing.T, cal *Calendar)
+	}{
+		{
+			name: "normalizes holidays",
+			db: fakeDB{
+				tz:    loc,
+				hours: [][]any{{int(time.Monday), 9 * 3600, 17 * 3600}},
+				holidays: [][]any{{
+					time.Date(2024, 7, 4, 15, 30, 0, 0, time.UTC), // not midnight
+				}},
+			},
+			validate: func(t *testing.T, cal *Calendar) {
+				day := time.Date(2024, 7, 4, 0, 0, 0, 0, cal.Location)
+				if _, ok := cal.Holidays[day]; !ok {
+					t.Fatalf("expected holiday to be normalized")
+				}
+			},
+		},
+		{
+			name: "loads varying business hours",
+			db: fakeDB{
+				tz: loc,
+				hours: [][]any{
+					{int(time.Monday), 8 * 3600, 12 * 3600},
+					{int(time.Tuesday), 10 * 3600, 15 * 3600},
+				},
+			},
+			validate: func(t *testing.T, cal *Calendar) {
+				m := cal.Hours[time.Monday]
+				if m.StartSec != 8*3600 || m.EndSec != 12*3600 {
+					t.Fatalf("unexpected Monday hours: %+v", m)
+				}
+				tu := cal.Hours[time.Tuesday]
+				if tu.StartSec != 10*3600 || tu.EndSec != 15*3600 {
+					t.Fatalf("unexpected Tuesday hours: %+v", tu)
+				}
+			},
+		},
+	}
 
-    cal, err := LoadCalendar(context.Background(), db, "cal-1")
-    if err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
-    if cal.Location == nil || cal.Location.String() == "" {
-        t.Fatalf("expected location to be set")
-    }
-    if _, ok := cal.Hours[time.Monday]; !ok {
-        t.Fatalf("expected Monday hours to be set")
-    }
-    // verify holiday normalized to midnight in tz
-    day := time.Date(2024, 7, 4, 0, 0, 0, 0, cal.Location)
-    if _, ok := cal.Holidays[day]; !ok {
-        t.Fatalf("expected holiday to be loaded")
-    }
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			cal, err := LoadCalendar(context.Background(), tt.db, "cal-1")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cal.Location == nil || cal.Location.String() == "" {
+				t.Fatalf("expected location to be set")
+			}
+			tt.validate(t, cal)
+		})
+	}
 }
-

--- a/internal/sla/sla_test.go
+++ b/internal/sla/sla_test.go
@@ -21,27 +21,61 @@ func testCalendar() *Calendar {
 	}
 }
 
-func TestBusinessDurationBasic(t *testing.T) {
-	cal := testCalendar()
-	loc := cal.Location
-	start := time.Date(2024, 7, 1, 16, 0, 0, 0, loc) // Mon 4pm
-	end := time.Date(2024, 7, 2, 10, 0, 0, 0, loc)   // Tue 10am
-	d := cal.BusinessDuration(start, end)
-	if d != 2*time.Hour {
-		t.Fatalf("expected 2h got %v", d)
+func TestBusinessDuration(t *testing.T) {
+	loc, _ := time.LoadLocation("America/New_York")
+	tests := []struct {
+		name     string
+		start    time.Time
+		end      time.Time
+		holidays []time.Time
+		want     time.Duration
+	}{
+		{
+			name:  "on boundaries",
+			start: time.Date(2024, 7, 1, 9, 0, 0, 0, loc),
+			end:   time.Date(2024, 7, 1, 17, 0, 0, 0, loc),
+			want:  8 * time.Hour,
+		},
+		{
+			name:  "overnight",
+			start: time.Date(2024, 7, 1, 16, 0, 0, 0, loc), // Mon 4pm
+			end:   time.Date(2024, 7, 2, 10, 0, 0, 0, loc), // Tue 10am
+			want:  2 * time.Hour,
+		},
+		{
+			name:  "weekend span",
+			start: time.Date(2024, 7, 5, 16, 0, 0, 0, loc), // Fri 4pm
+			end:   time.Date(2024, 7, 8, 10, 0, 0, 0, loc), // Mon 10am
+			want:  2 * time.Hour,
+		},
+		{
+			name:  "consecutive holidays",
+			start: time.Date(2024, 7, 2, 16, 0, 0, 0, loc), // Tue 4pm
+			end:   time.Date(2024, 7, 5, 10, 0, 0, 0, loc), // Fri 10am
+			holidays: []time.Time{
+				time.Date(2024, 7, 3, 0, 0, 0, 0, loc),
+				time.Date(2024, 7, 4, 0, 0, 0, 0, loc),
+			},
+			want: 2 * time.Hour,
+		},
+		{
+			name:  "reversed inputs",
+			start: time.Date(2024, 7, 2, 10, 0, 0, 0, loc), // Tue 10am
+			end:   time.Date(2024, 7, 1, 16, 0, 0, 0, loc), // Mon 4pm
+			want:  2 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cal := testCalendar()
+			for _, h := range tt.holidays {
+				cal.Holidays[h.In(cal.Location)] = struct{}{}
+			}
+			got := cal.BusinessDuration(tt.start, tt.end)
+			if got != tt.want {
+				t.Fatalf("expected %v got %v", tt.want, got)
+			}
+		})
 	}
 }
-
-func TestBusinessDurationHoliday(t *testing.T) {
-	cal := testCalendar()
-	loc := cal.Location
-	holiday := time.Date(2024, 7, 4, 0, 0, 0, 0, loc)
-	cal.Holidays[holiday] = struct{}{}
-	start := time.Date(2024, 7, 3, 16, 0, 0, 0, loc)
-	end := time.Date(2024, 7, 5, 10, 0, 0, 0, loc)
-	d := cal.BusinessDuration(start, end)
-	if d != 2*time.Hour {
-		t.Fatalf("expected 2h got %v", d)
-	}
-}
-


### PR DESCRIPTION
## Summary
- add table-driven SLA duration tests for boundary and holiday edge cases
- table-drive calendar loading tests for holiday normalization and varying business hours

## Testing
- `go test ./internal/sla`


------
https://chatgpt.com/codex/tasks/task_e_68ba8dae743c8322817edb2a249fadfc