### PR TITLE
helm: document local auth secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ Examples:
   helm upgrade --install helpdesk ./helm/helpdesk -n helpdesk \
     -f helm/helpdesk/examples/values-local-auth.yaml
   ```
+- To supply secrets out-of-band, create a `Secret` with the local auth keys and point the chart to it:
+  ```bash
+  kubectl create secret generic helpdesk-auth \
+    --from-literal=AUTH_LOCAL_SECRET=change-me \
+    --from-literal=ADMIN_PASSWORD=admin
+  helm upgrade --install helpdesk ./helm/helpdesk -n helpdesk --create-namespace \
+    -f helm/helpdesk/examples/values-local-auth.yaml \
+    --set secrets.name=helpdesk-auth --set secrets.enabled=true
+  ```
 - OIDC (Authentik/Keycloak), both frontends, CORS + JWKS configured:
   ```bash
   helm upgrade --install helpdesk ./helm/helpdesk -n helpdesk \

--- a/helm/helpdesk/examples/values-local-auth.yaml
+++ b/helm/helpdesk/examples/values-local-auth.yaml
@@ -56,7 +56,6 @@ env:
 
   # Local auth (no OIDC)
   AUTH_MODE: "local"
-  AUTH_LOCAL_SECRET: "change-me"
   OIDC_ISSUER: ""
   OIDC_JWKS_URL: ""
 
@@ -66,3 +65,9 @@ env:
   MINIO_SECRET_KEY: ""
   MINIO_BUCKET: "attachments"
   MINIO_USE_SSL: "false"
+
+secrets:
+  enabled: true
+  data:
+    AUTH_LOCAL_SECRET: "change-me"
+    ADMIN_PASSWORD: "admin"

--- a/helm/helpdesk/values.yaml
+++ b/helm/helpdesk/values.yaml
@@ -72,8 +72,7 @@ env:
   REDIS_TIMEOUT_MS: "2000"
   OBJECTSTORE_TIMEOUT_MS: "10000"
   # API auth (optional)
-  AUTH_MODE: "oidc"
-  AUTH_LOCAL_SECRET: ""
+  AUTH_MODE: "local"
   OIDC_ISSUER: ""
   OIDC_JWKS_URL: ""
   # Object storage (optional)
@@ -105,17 +104,14 @@ imagePullSecrets: []
 
 # Optional Kubernetes Secret support for sensitive env vars
 secrets:
-  enabled: false
+  enabled: true
   # If you already have a Secret, set its name here and it will be referenced.
   # When empty and enabled=true, this chart will create a Secret named
   # "{{ include \"helpdesk.fullname\" . }}-secret" with the key/values below.
   name: ""
-  data: {}
-  # Example:
-  # data:
-  #   DATABASE_URL: "postgres://user:pass@postgres:5432/helpdesk?sslmode=disable"
-  #   AUTH_LOCAL_SECRET: "super-secret"
-  #   ADMIN_PASSWORD: "admin"
+  data:
+    AUTH_LOCAL_SECRET: "change-me"
+    ADMIN_PASSWORD: "admin"
 
 # Optional persistence for FILESTORE_PATH (filesystem object store)
 persistence:


### PR DESCRIPTION
## Summary
- enable local auth by default and wire AUTH_LOCAL_SECRET and ADMIN_PASSWORD through Helm values
- provide example values using secret-backed local auth
- explain creating and referencing Secrets for local auth in README

## Testing
- `go test ./...`
- `helm lint helm/helpdesk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb24777d8832288293281cd43e80a