### PR TITLE
api: seed local admin when password set

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A minimal FootPrints-style ticketing system scaffold in Go, with PostgreSQL migr
    ```
 
 Notes:
-- In `AUTH_MODE=local` and `ENV=dev`, an admin user is auto-seeded. Set `ADMIN_PASSWORD` to control it; otherwise a random password is generated and logged once.
+- In `AUTH_MODE=local`, an admin user is auto-seeded if `ADMIN_PASSWORD` is set or when running with `ENV=dev`. If `ADMIN_PASSWORD` is omitted, a random password is generated and logged once.
 - For MinIO, set `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_BUCKET`, `MINIO_USE_SSL` and omit `FILESTORE_PATH`.
 
 ## Local Development
@@ -203,7 +203,7 @@ API (cmd/api):
 - `OIDC_GROUP_CLAIM`: JWT claim name containing group roles (default `groups`).
 - `AUTH_MODE`: `oidc` or `local`.
 - `AUTH_LOCAL_SECRET`: HMAC secret for local auth cookie JWTs.
-- `ADMIN_PASSWORD`: initial admin password in dev local-auth mode.
+- `ADMIN_PASSWORD`: initial admin password for local auth; if omitted in dev, a random password is generated and logged once.
 - `FILESTORE_PATH`: local path for attachments (filesystem store).
 - `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_BUCKET`, `MINIO_USE_SSL`: S3/MinIO settings.
 - `REDIS_TIMEOUT_MS`: per-call Redis timeout in milliseconds (default 2000). Applies to readiness ping and queue operations.


### PR DESCRIPTION
## Summary
- seed local admin user when AUTH_MODE=local and ADMIN_PASSWORD set
- clarify admin seeding and password logging in README

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./...` *(fails: go: no such tool "covdata")*
- `TEST_BYPASS_AUTH=true go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbb4ce3e848322a880c5c512320f41