### PR TITLE
helm: split ingress paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,9 @@ jobs:
           version: v3.13.3
       - name: Lint Helm chart
         run: helm lint helm/helpdesk
+      - name: Verify ingress API mapping
+        run: |
+          helm template test helm/helpdesk > rendered.yaml
+          grep -A 5 'path: /api' rendered.yaml | grep 'name: test-helpdesk-api'
       - name: Package Helm chart
         run: helm package helm/helpdesk

--- a/helm/helpdesk/templates/ingress.yaml
+++ b/helm/helpdesk/templates/ingress.yaml
@@ -7,32 +7,25 @@ metadata:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
 spec:
   rules:
+    {{- $root := . }}
     {{- range .Values.ingress.hosts }}
     - host: {{ .host }}
       http:
         paths:
-          {{- $root := $ }}
-          {{- range .paths }}
-          - path: {{ .path }}
-            pathType: {{ .pathType }}
+          - path: /api
+            pathType: Prefix
             backend:
               service:
-                {{- if $root.Values.frontendInternal.enabled }}
-                {{- if or (regexMatch "^/api($|/)" .path) (regexMatch "^/swagger" .path) }}
                 name: {{ include "helpdesk.fullname" $root }}-api
                 port:
                   name: http
-                {{- else }}
-                name: {{ include "helpdesk.fullname" $root }}-frontend-internal
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{- if $root.Values.frontendInternal.enabled }}{{ include "helpdesk.fullname" $root }}-frontend-internal{{ else }}{{ include "helpdesk.fullname" $root }}-api{{ end }}
                 port:
                   name: http
-                {{- end }}
-                {{- else }}
-                name: {{ include "helpdesk.fullname" $root }}-api
-                port:
-                  name: http
-                {{- end }}
-          {{- end }}
     {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/helm/helpdesk/values.yaml
+++ b/helm/helpdesk/values.yaml
@@ -39,13 +39,6 @@ ingress:
   className: nginx
   hosts:
     - host: helpdesk.local
-      paths:
-        - path: /
-          pathType: Prefix
-        - path: /api
-          pathType: Prefix
-        - path: /swagger
-          pathType: Prefix
   tls: []
 
 # Separate ingress for requester portal (optional)


### PR DESCRIPTION
## Summary
- define explicit /api and / ingress rules in chart
- drop regex-based backend switching
- assert /api routes to API service in CI

## Testing
- `go test -cover ./...` *(fails: go: no such tool "covdata")*
- `go test ./...`
- `helm lint helm/helpdesk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb75c596c8322ab9f2559683ae5bc