### PR TITLE
Helm improvements and bugfixes, prep for v0.4.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,9 @@ jobs:
           version: v3.13.3
       - name: Lint Helm chart
         run: helm lint helm/helpdesk
+      - name: Verify ingress API mapping
+        run: |
+          helm template test helm/helpdesk > rendered.yaml
+          grep -A 5 'path: /api' rendered.yaml | grep 'name: test-helpdesk-api'
       - name: Package Helm chart
         run: helm package helm/helpdesk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       packages: write
     strategy:
       matrix:
+        name: [api, worker, internal-frontend, requester-frontend]
         platform: [linux/amd64, linux/arm64]
         include:
           - name: api
@@ -37,7 +38,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{ matrix.file }}
+          file: ${{ matrix.include[0].file }}
           push: true
           platforms: ${{ matrix.platform }}
           tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{ matrix.include[0].file }}
+          file: ${{ matrix.file }}
           push: true
           platforms: ${{ matrix.platform }}
           tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         name: [api, worker, internal-frontend, requester-frontend]
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
         include:
           - name: api
             file: Dockerfile.api

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A minimal FootPrints-style ticketing system scaffold in Go, with PostgreSQL migr
    ```
 
 Notes:
-- In `AUTH_MODE=local` and `ENV=dev`, an admin user is auto-seeded. Set `ADMIN_PASSWORD` to control it; otherwise a random password is generated and logged once.
+- In `AUTH_MODE=local`, an admin user is auto-seeded if `ADMIN_PASSWORD` is set or when running with `ENV=dev`. If `ADMIN_PASSWORD` is omitted, a random password is generated and logged once.
 - For MinIO, set `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_BUCKET`, `MINIO_USE_SSL` and omit `FILESTORE_PATH`.
 
 ## Local Development
@@ -203,7 +203,7 @@ API (cmd/api):
 - `OIDC_GROUP_CLAIM`: JWT claim name containing group roles (default `groups`).
 - `AUTH_MODE`: `oidc` or `local`.
 - `AUTH_LOCAL_SECRET`: HMAC secret for local auth cookie JWTs.
-- `ADMIN_PASSWORD`: initial admin password in dev local-auth mode.
+- `ADMIN_PASSWORD`: initial admin password for local auth; if omitted in dev, a random password is generated and logged once.
 - `FILESTORE_PATH`: local path for attachments (filesystem store).
 - `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_BUCKET`, `MINIO_USE_SSL`: S3/MinIO settings.
 - `REDIS_TIMEOUT_MS`: per-call Redis timeout in milliseconds (default 2000). Applies to readiness ping and queue operations.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ Examples:
   helm upgrade --install helpdesk ./helm/helpdesk -n helpdesk \
     -f helm/helpdesk/examples/values-local-auth.yaml
   ```
+- To supply secrets out-of-band, create a `Secret` with the local auth keys and point the chart to it:
+  ```bash
+  kubectl create secret generic helpdesk-auth \
+    --from-literal=AUTH_LOCAL_SECRET=change-me \
+    --from-literal=ADMIN_PASSWORD=admin
+  helm upgrade --install helpdesk ./helm/helpdesk -n helpdesk --create-namespace \
+    -f helm/helpdesk/examples/values-local-auth.yaml \
+    --set secrets.name=helpdesk-auth --set secrets.enabled=true
+  ```
 - OIDC (Authentik/Keycloak), both frontends, CORS + JWKS configured:
   ```bash
   helm upgrade --install helpdesk ./helm/helpdesk -n helpdesk \

--- a/helm/helpdesk/Chart.yaml
+++ b/helm/helpdesk/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: helpdesk
 description: FootPrints-style helpdesk (Go) — API + Worker
 type: application
-version: 0.4.0
+version: 0.4.3
 appVersion: "0.4.0"

--- a/helm/helpdesk/examples/values-local-auth.yaml
+++ b/helm/helpdesk/examples/values-local-auth.yaml
@@ -56,7 +56,6 @@ env:
 
   # Local auth (no OIDC)
   AUTH_MODE: "local"
-  AUTH_LOCAL_SECRET: "change-me"
   OIDC_ISSUER: ""
   OIDC_JWKS_URL: ""
 
@@ -66,3 +65,9 @@ env:
   MINIO_SECRET_KEY: ""
   MINIO_BUCKET: "attachments"
   MINIO_USE_SSL: "false"
+
+secrets:
+  enabled: true
+  data:
+    AUTH_LOCAL_SECRET: "change-me"
+    ADMIN_PASSWORD: "admin"

--- a/helm/helpdesk/templates/ingress.yaml
+++ b/helm/helpdesk/templates/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
 spec:
+  ingressClassName: {{ .Values.ingress.className }}
   rules:
     {{- $root := . }}
     {{- range .Values.ingress.hosts }}

--- a/helm/helpdesk/templates/ingress.yaml
+++ b/helm/helpdesk/templates/ingress.yaml
@@ -7,32 +7,25 @@ metadata:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
 spec:
   rules:
+    {{- $root := . }}
     {{- range .Values.ingress.hosts }}
     - host: {{ .host }}
       http:
         paths:
-          {{- $root := $ }}
-          {{- range .paths }}
-          - path: {{ .path }}
-            pathType: {{ .pathType }}
+          - path: /api
+            pathType: Prefix
             backend:
               service:
-                {{- if $root.Values.frontendInternal.enabled }}
-                {{- if or (regexMatch "^/api($|/)" .path) (regexMatch "^/swagger" .path) }}
                 name: {{ include "helpdesk.fullname" $root }}-api
                 port:
                   name: http
-                {{- else }}
-                name: {{ include "helpdesk.fullname" $root }}-frontend-internal
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{- if $root.Values.frontendInternal.enabled }}{{ include "helpdesk.fullname" $root }}-frontend-internal{{ else }}{{ include "helpdesk.fullname" $root }}-api{{ end }}
                 port:
                   name: http
-                {{- end }}
-                {{- else }}
-                name: {{ include "helpdesk.fullname" $root }}-api
-                port:
-                  name: http
-                {{- end }}
-          {{- end }}
     {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/helm/helpdesk/templates/ingress.yaml
+++ b/helm/helpdesk/templates/ingress.yaml
@@ -24,7 +24,11 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ if $root.Values.frontendInternal.enabled }}{{ include "helpdesk.fullname" $root }}-frontend-internal{{ else }}{{ include "helpdesk.fullname" $root }}-api{{ end }}
+                {{- $frontendServiceName := (printf "%s-frontend-internal" (include "helpdesk.fullname" $root)) -}}
+                {{- if not $root.Values.frontendInternal.enabled }}
+                  {{- $frontendServiceName = (printf "%s-api" (include "helpdesk.fullname" $root)) -}}
+                {{- end }}
+                name: {{ $frontendServiceName }}
                 port:
                   name: http
     {{- end }}

--- a/helm/helpdesk/templates/ingress.yaml
+++ b/helm/helpdesk/templates/ingress.yaml
@@ -23,12 +23,12 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{- if $root.Values.frontendInternal.enabled }}{{ include "helpdesk.fullname" $root }}-frontend-internal{{ else }}{{ include "helpdesk.fullname" $root }}-api{{ end }}
+                name: {{ if $root.Values.frontendInternal.enabled }}{{ include "helpdesk.fullname" $root }}-frontend-internal{{ else }}{{ include "helpdesk.fullname" $root }}-api{{ end }}
                 port:
                   name: http
     {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
-    {{- toYaml .Values.ingress.tls | nindent 8 }}
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/helm/helpdesk/values.yaml
+++ b/helm/helpdesk/values.yaml
@@ -39,13 +39,6 @@ ingress:
   className: nginx
   hosts:
     - host: helpdesk.local
-      paths:
-        - path: /
-          pathType: Prefix
-        - path: /api
-          pathType: Prefix
-        - path: /swagger
-          pathType: Prefix
   tls: []
 
 # Separate ingress for requester portal (optional)

--- a/helm/helpdesk/values.yaml
+++ b/helm/helpdesk/values.yaml
@@ -104,7 +104,7 @@ secrets:
   name: ""
   data:
     AUTH_LOCAL_SECRET: "change-me"
-    ADMIN_PASSWORD: "admin"
+    ADMIN_PASSWORD: ""
 
 # Optional persistence for FILESTORE_PATH (filesystem object store)
 persistence:

--- a/helm/helpdesk/values.yaml
+++ b/helm/helpdesk/values.yaml
@@ -72,8 +72,7 @@ env:
   REDIS_TIMEOUT_MS: "2000"
   OBJECTSTORE_TIMEOUT_MS: "10000"
   # API auth (optional)
-  AUTH_MODE: "oidc"
-  AUTH_LOCAL_SECRET: ""
+  AUTH_MODE: "local"
   OIDC_ISSUER: ""
   OIDC_JWKS_URL: ""
   # Object storage (optional)
@@ -105,17 +104,14 @@ imagePullSecrets: []
 
 # Optional Kubernetes Secret support for sensitive env vars
 secrets:
-  enabled: false
+  enabled: true
   # If you already have a Secret, set its name here and it will be referenced.
   # When empty and enabled=true, this chart will create a Secret named
   # "{{ include \"helpdesk.fullname\" . }}-secret" with the key/values below.
   name: ""
-  data: {}
-  # Example:
-  # data:
-  #   DATABASE_URL: "postgres://user:pass@postgres:5432/helpdesk?sslmode=disable"
-  #   AUTH_LOCAL_SECRET: "super-secret"
-  #   ADMIN_PASSWORD: "admin"
+  data:
+    AUTH_LOCAL_SECRET: "change-me"
+    ADMIN_PASSWORD: "admin"
 
 # Optional persistence for FILESTORE_PATH (filesystem object store)
 persistence:

--- a/web/internal/src/components/Login.tsx
+++ b/web/internal/src/components/Login.tsx
@@ -33,7 +33,7 @@ export default function Login() {
     <div style={{ maxWidth: 360, margin: '10vh auto', background: '#fff', padding: 24, borderRadius: 8 }}>
       <Typography.Title level={4} style={{ textAlign: 'center' }}>Sign in</Typography.Title>
       {error && <Alert type="error" message={error} style={{ marginBottom: 12 }} />}
-      <Form layout="vertical" onFinish={onFinish} initialValues={{ username: 'admin', password: 'admin' }}>
+      <Form layout="vertical" onFinish={onFinish} initialValues={(import.meta as any).env?.DEV ? { username: 'admin', password: 'admin' } : {}}>
         <Form.Item label="Username" name="username" rules={[{ required: true }]}>
           <Input autoFocus />
         </Form.Item>
@@ -43,9 +43,11 @@ export default function Login() {
         <Button type="primary" htmlType="submit" block loading={loading}>
           Log in
         </Button>
-        <Typography.Paragraph type="secondary" style={{ marginTop: 12, textAlign: 'center' }}>
-          Dev default: admin / admin
-        </Typography.Paragraph>
+        {(import.meta as any).env?.DEV && (
+          <Typography.Paragraph type="secondary" style={{ marginTop: 12, textAlign: 'center' }}>
+            Dev default: admin / admin
+          </Typography.Paragraph>
+        )}
       </Form>
     </div>
   );


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the Helm chart, Kubernetes ingress configuration, and local authentication setup for the helpdesk application. The main themes are: simplifying and correcting ingress routing, improving secret management for local authentication, and clarifying admin user seeding behavior. Below are the most important changes:

**Helm Chart and Ingress Improvements:**
- Updated the ingress template (`helm/helpdesk/templates/ingress.yaml`) to explicitly map `/api` paths to the API service and `/` to the frontend, simplifying and making routing more predictable. Also added `ingressClassName` and improved handling of TLS configuration. (`[helm/helpdesk/templates/ingress.yamlR9-R33](diffhunk://#diff-9c530641c6a669debd7033631e9e4eb6d1b9b2369220bfafcbdab8020da9e6d8R9-R33)`)
- Removed the explicit `paths` list from the default ingress hosts in `values.yaml` and updated the example values files to match the new ingress routing logic. (`[helm/helpdesk/values.yamlL42-L48](diffhunk://#diff-0087887999ee430dd2c6f8418f4e1cfe0bfbede73d1f626882e03a3ff0fc4953L42-L48)`)

**Secret Management and Local Auth:**
- Enabled Kubernetes Secret support by default in `values.yaml` and provided example secret data for local authentication, including `AUTH_LOCAL_SECRET` and `ADMIN_PASSWORD`. Also updated example values files and documentation to show how to supply secrets out-of-band. (`[[1]](diffhunk://#diff-0087887999ee430dd2c6f8418f4e1cfe0bfbede73d1f626882e03a3ff0fc4953L108-R107)`, `[[2]](diffhunk://#diff-40a2b01537eb501dfa11842f60b4e43956e608191c2307868a9cde6cc1ff8cd6R68-R73)`, `[[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R90-R98)`)
- Changed the default `AUTH_MODE` to `local` in `values.yaml` for easier local development and removed `AUTH_LOCAL_SECRET` from the environment section in the example values file, moving it to secrets. (`[[1]](diffhunk://#diff-0087887999ee430dd2c6f8418f4e1cfe0bfbede73d1f626882e03a3ff0fc4953L75-R68)`, `[[2]](diffhunk://#diff-40a2b01537eb501dfa11842f60b4e43956e608191c2307868a9cde6cc1ff8cd6L59)`)

**Admin User Seeding Logic:**
- Updated the admin user seeding logic in `cmd/api/main.go` so that an admin user is seeded for local auth if either `ENV=dev` or `ADMIN_PASSWORD` is set, and clarified this behavior in the documentation. (`[[1]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL649-R651)`, `[[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R36)`, `[[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L197-R206)`)
- Added documentation and comments to clarify that `seedLocalAdmin` is safe to call multiple times and only inserts an admin user if one does not already exist. (`[cmd/api/main.goR1086-R1087](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afR1086-R1087)`)

**CI/CD and Versioning:**
- Updated the Helm chart version to `0.4.3` in `Chart.yaml`. (`[helm/helpdesk/Chart.yamlL5-R5](diffhunk://#diff-e91b0a95fe9269ae58471db77b7506a4afbd680c996a78db841ba4bbbd460b17L5-R5)`)
- Added a CI workflow step to verify that ingress `/api` paths are mapped to the correct service using `helm template` and `grep`. (`[.github/workflows/ci.ymlR40-R43](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR40-R43)`)
- Updated the release workflow to build images for specific components (`api`, `worker`, `internal-frontend`, `requester-frontend`) and only for `linux/amd64`. (`[.github/workflows/release.ymlL16-R17](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L16-R17)`)