### PR TITLE
fix: guard nil user before asset handler type assertions

### DIFF
--- a/cmd/api/assets/attachments.go
+++ b/cmd/api/assets/attachments.go
@@ -113,8 +113,16 @@ func PresignAssetUpload(a *app.App) gin.HandlerFunc {
 func FinalizeAssetAttachment(a *app.App) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		assetID := c.Param("id")
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
 
 		type req struct {
 			AttachmentID string `json:"attachment_id" binding:"required"`

--- a/cmd/api/assets/handlers.go
+++ b/cmd/api/assets/handlers.go
@@ -45,9 +45,13 @@ func CreateAsset(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
-		if u == nil {
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
 			return
 		}
@@ -111,9 +115,13 @@ func UpdateAsset(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
-		if u == nil {
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
 			return
 		}
@@ -154,9 +162,13 @@ func DeleteAsset(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
-		if u == nil {
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
 			return
 		}
@@ -187,9 +199,13 @@ func AssignAsset(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
-		if u == nil {
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
 			return
 		}

--- a/cmd/api/assets/workflows_handlers.go
+++ b/cmd/api/assets/workflows_handlers.go
@@ -19,8 +19,16 @@ func RequestStatusChange(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
 
 		assetID, err := uuid.Parse(c.Param("id"))
 		if err != nil {
@@ -58,8 +66,16 @@ func ApproveWorkflow(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
 
 		workflowID, err := uuid.Parse(c.Param("id"))
 		if err != nil {
@@ -96,8 +112,16 @@ func RejectWorkflow(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
 
 		workflowID, err := uuid.Parse(c.Param("id"))
 		if err != nil {
@@ -134,8 +158,16 @@ func CheckoutAsset(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
 
 		assetID, err := uuid.Parse(c.Param("id"))
 		if err != nil {
@@ -171,8 +203,16 @@ func CheckinAsset(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
 
 		var req CheckinRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -240,8 +280,16 @@ func CreateRelationship(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
 
 		parentAssetID, err := uuid.Parse(c.Param("id"))
 		if err != nil {
@@ -336,8 +384,16 @@ func BulkUpdateAssets(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
 
 		var req BulkUpdateRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -365,8 +421,16 @@ func BulkAssignAssets(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
 
 		var req BulkAssignRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -421,8 +485,16 @@ func ImportAssets(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
 
 		file, _, err := c.Request.FormFile("file")
 		if err != nil {
@@ -456,8 +528,16 @@ func ExportAssets(a *app.App) gin.HandlerFunc {
 			return
 		}
 
-		u, _ := c.Get("user")
-		authUser := u.(auth.AuthUser)
+		u, ok := c.Get("user")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
+		authUser, ok := u.(auth.AuthUser)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			return
+		}
 
 		var req ExportRequest
 		if err := c.ShouldBindJSON(&req); err != nil {


### PR DESCRIPTION
## Summary
- ensure asset handlers return 401 when no user is in context
- guard workflow and attachment handlers against nil user assertions

## Testing
- `go test -cover ./...` *(warnings: `go: no such tool "covdata"` for some packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c12092c5448322943b4551b1a7cf5b