### PR TITLE
test: stub Begin on fake DBs

### DIFF
--- a/cmd/api/auth/auth_jwks_test.go
+++ b/cmd/api/auth/auth_jwks_test.go
@@ -78,6 +78,10 @@ func (db *fakeDB) Exec(ctx context.Context, sql string, args ...interface{}) (pg
 	return pgconn.CommandTag{}, nil
 }
 
+func (db *fakeDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 func TestAuth_WithJWKS_ValidToken(t *testing.T) {
 	// generate RSA keypair
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/cmd/api/events/events_test.go
+++ b/cmd/api/events/events_test.go
@@ -124,6 +124,10 @@ func (db *fakeEventDB) Exec(ctx context.Context, sql string, args ...interface{}
 	return pgconn.CommandTag{}, nil
 }
 
+func (db *fakeEventDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 func TestStreamResume(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	db := &fakeEventDB{}

--- a/cmd/api/export_test.go
+++ b/cmd/api/export_test.go
@@ -115,6 +115,10 @@ func (db *exportDB) Exec(ctx context.Context, sql string, args ...interface{}) (
 	return pgconn.CommandTag{}, nil
 }
 
+func (db *exportDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 func TestExportTickets(t *testing.T) {
 	store := newFakeObjectStore()
 

--- a/cmd/api/main_dbtimeout_test.go
+++ b/cmd/api/main_dbtimeout_test.go
@@ -62,6 +62,10 @@ func (s slowDB) Exec(ctx context.Context, sql string, args ...interface{}) (pgco
 	return pgconn.CommandTag{}, context.DeadlineExceeded
 }
 
+func (s slowDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 func TestDBTimeout_Readyz(t *testing.T) {
 	t.Setenv("ENV", "test")
 	// Tight DB timeout to force cancellation

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -185,6 +185,10 @@ func (db readyzDB) Exec(ctx context.Context, sql string, args ...interface{}) (p
 	return pgconn.CommandTag{}, nil
 }
 
+func (db readyzDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 func setMail(ms map[string]string) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -421,6 +425,10 @@ func (db *csatTestDB) Exec(ctx context.Context, sql string, args ...interface{})
 	return pgconn.NewCommandTag(fmt.Sprintf("UPDATE %d", db.rows)), nil
 }
 
+func (db *csatTestDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 func TestSubmitCSAT(t *testing.T) {
 	db := &csatTestDB{rows: 1}
 	cfg := Config{Env: "test"}
@@ -468,6 +476,10 @@ func (db *recordDB) QueryRow(ctx context.Context, sql string, args ...interface{
 
 func (db *recordDB) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
 	return pgconn.CommandTag{}, nil
+}
+
+func (db *recordDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
 }
 
 func TestListTickets(t *testing.T) {
@@ -570,6 +582,10 @@ func (db *attachmentDB) Exec(ctx context.Context, sql string, args ...interface{
 	return pgconn.CommandTag{}, nil
 }
 
+func (db *attachmentDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 func TestGetAttachment_MinIOPresign(t *testing.T) {
 	db := &attachmentDB{}
 	mc, err := minio.New("localhost:9000", &minio.Options{
@@ -639,6 +655,10 @@ func (db *traversalAttachmentDB) Exec(ctx context.Context, sql string, args ...i
 	return pgconn.CommandTag{}, nil
 }
 
+func (db *traversalAttachmentDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 func TestGetAttachment_FileStoreTraversalBlocked(t *testing.T) {
 	dir := t.TempDir()
 	// Configure file store path (no MinIO), and DB returns a traversal key
@@ -667,6 +687,10 @@ func (db *statusDB) QueryRow(ctx context.Context, sql string, args ...interface{
 func (db *statusDB) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
 	db.called = true
 	return pgconn.CommandTag{}, nil
+}
+
+func (db *statusDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
 }
 
 func TestAddStatusHistory_Invalid(t *testing.T) {
@@ -768,6 +792,10 @@ func (db *updateCaptureDB) Exec(ctx context.Context, sql string, args ...interfa
 	return pgconn.CommandTag{}, nil
 }
 
+func (db *updateCaptureDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 func TestUpdateTicket_LowercaseStatus_Normalized(t *testing.T) {
 	db := &updateCaptureDB{}
 	app := NewApp(Config{Env: "test", TestBypassAuth: true}, db, nil, nil, nil)
@@ -837,6 +865,10 @@ func (db *eventCaptureDB) QueryRow(ctx context.Context, sql string, args ...inte
 func (db *eventCaptureDB) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
 	db.execs = append(db.execs, sql)
 	return pgconn.CommandTag{}, nil
+}
+
+func (db *eventCaptureDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
 }
 
 func TestCreateTicket_EventRecorded(t *testing.T) {
@@ -943,6 +975,10 @@ func (db *requesterDB) Exec(ctx context.Context, sql string, args ...interface{}
 	return pgconn.CommandTag{}, nil
 }
 
+func (db *requesterDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 func TestCreateRequester(t *testing.T) {
 	db := &requesterDB{}
 	app := NewApp(Config{Env: "test", TestBypassAuth: true}, db, nil, nil, nil)
@@ -1012,6 +1048,10 @@ func (db *nonRequesterDB) QueryRow(ctx context.Context, s string, args ...interf
 
 func (db *nonRequesterDB) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
 	return pgconn.CommandTag{}, nil
+}
+
+func (db *nonRequesterDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
 }
 
 func TestUpdateRequester_OnlyRequesterRole(t *testing.T) {

--- a/cmd/api/queues/queues_test.go
+++ b/cmd/api/queues/queues_test.go
@@ -48,6 +48,10 @@ func (db *qdb) Exec(ctx context.Context, sql string, args ...interface{}) (pgcon
 	return pgconn.CommandTag{}, nil
 }
 
+func (db *qdb) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 func TestQueueList(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	db := &qdb{rows: []qrow{{Queue{ID: "1", Name: "Alpha"}}, {Queue{ID: "2", Name: "Beta"}}}}

--- a/cmd/api/tickets/assign_test.go
+++ b/cmd/api/tickets/assign_test.go
@@ -47,6 +47,10 @@ func (db *assignDB) QueryRow(ctx context.Context, sql string, args ...interface{
 	return &assignRow{t}
 }
 
+func (db *assignDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 func TestAssign(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	db := &assignDB{}

--- a/cmd/api/tickets/tickets_test.go
+++ b/cmd/api/tickets/tickets_test.go
@@ -151,6 +151,10 @@ func (db *listDB) Exec(ctx context.Context, sql string, args ...interface{}) (pg
 	return pgconn.CommandTag{}, nil
 }
 
+func (db *listDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 func TestTicketListPagination(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	now := time.Now().UTC()

--- a/cmd/api/watchers/watchers_test.go
+++ b/cmd/api/watchers/watchers_test.go
@@ -53,6 +53,10 @@ func (db *fakeDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.Com
 	return pgconn.CommandTag{}, nil
 }
 
+func (db *fakeDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 type fakeRows struct {
 	list []string
 	i    int

--- a/cmd/worker/imap_test.go
+++ b/cmd/worker/imap_test.go
@@ -88,6 +88,10 @@ func (f *fakeDB) Exec(ctx context.Context, sql string, args ...interface{}) (pgc
 	return pgconn.CommandTag{}, nil
 }
 
+func (f *fakeDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	return nil, nil
+}
+
 const sampleEmail = "Subject: Test\r\nFrom: sender@example.com\r\nMessage-Id: <msg1@example.com>\r\nMIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=BOUND\r\n\r\n--BOUND\r\nContent-Type: text/plain\r\n\r\nhello body\r\n--BOUND\r\nContent-Type: text/plain; name=\"note.txt\"\r\nContent-Disposition: attachment; filename=\"note.txt\"\r\n\r\nattachment data\r\n--BOUND--\r\n"
 
 func TestProcessIMAPMessage_Attachment(t *testing.T) {


### PR DESCRIPTION
## Summary
- implement missing `Begin` method on test database fakes to satisfy `app.DB`

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./...` (warnings: `go: no such tool "covdata"`)


------
https://chatgpt.com/codex/tasks/task_e_68c132181b6c8322a53f337dd396c11a