### PR TITLE
fix: centralize asset export and type asset checkout

### DIFF
--- a/web/internal/src/components/assets/BulkOperations.tsx
+++ b/web/internal/src/components/assets/BulkOperations.tsx
@@ -144,16 +144,11 @@ export default function BulkOperations() {
 
   const handleExport = async () => {
     try {
-      // Manually fetch as blob since fetch does not support responseType
+      // Use centralized api utility for consistency
       const params = new URLSearchParams({ format: "csv" });
-      const res = await fetch(`/assets/export?${params.toString()}`, {
-        method: "GET",
-        credentials: "include",
-        // Add authentication headers here if needed, e.g.:
-        // headers: { Authorization: `Bearer ${yourToken}` },
+      const blob = await api.get<Blob>(`/assets/export?${params.toString()}`, {
+        responseType: "blob",
       });
-      if (!res.ok) throw new Error("Failed to export assets");
-      const blob = await res.blob();
 
       const url = window.URL.createObjectURL(blob);
       const link = document.createElement("a");
@@ -167,10 +162,9 @@ export default function BulkOperations() {
       link.remove();
       window.URL.revokeObjectURL(url);
       message.success("Assets exported successfully");
-    } catch (error: any) {
-      message.error(
-        `Export failed: ${error.response?.data?.error || error.message}`,
-      );
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { error?: string } }; message: string };
+      message.error(`Export failed: ${err.response?.data?.error || err.message}`);
     }
   };
 

--- a/web/internal/src/shared/api.ts
+++ b/web/internal/src/shared/api.ts
@@ -2,13 +2,19 @@ import type { components } from '../types/openapi';
 
 const API_BASE = '/api';
 
-export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, { credentials: 'include', ...init });
+interface ApiRequestInit extends RequestInit {
+  responseType?: 'json' | 'blob';
+}
+
+export async function apiFetch<T>(path: string, init: ApiRequestInit = {}): Promise<T> {
+  const { responseType, ...fetchInit } = init;
+  const res = await fetch(`${API_BASE}${path}`, { credentials: 'include', ...fetchInit });
   if (!res.ok) {
     const txt = await res.text().catch(() => '');
     throw new Error(`${res.status} ${txt}`);
   }
   if (res.status === 204) return undefined as unknown as T;
+  if (responseType === 'blob') return (await res.blob()) as unknown as T;
   return (await res.json()) as T;
 }
 
@@ -195,7 +201,7 @@ export async function downloadAttachment(
   if (!res.ok) throw new Error(await res.text());
   const blob = await res.blob();
   const cd = res.headers.get('Content-Disposition') || '';
-  const m = /filename\*=UTF-8''([^;]+)|filename="?([^";]+)"?/i.exec(cd);
+  const m = /filename\*=UTF-8''([^;]+)|filename="?([^\\";]+)"?/i.exec(cd);
   const fname = m ? decodeURIComponent(m[1] || m[2] || 'attachment') : 'attachment';
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -209,24 +215,24 @@ export async function downloadAttachment(
 
 // API object with common HTTP methods
 export const api = {
-  get: <T>(path: string, options?: RequestInit) => apiFetch<T>(path, options),
-  post: <T>(path: string, data?: any, options?: RequestInit) => apiFetch<T>(path, {
+  get: <T>(path: string, options?: ApiRequestInit) => apiFetch<T>(path, options),
+  post: <T>(path: string, data?: any, options?: ApiRequestInit) => apiFetch<T>(path, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: data ? JSON.stringify(data) : undefined,
     ...options,
   }),
-  put: <T>(path: string, data?: any, options?: RequestInit) => apiFetch<T>(path, {
-    method: 'PUT', 
+  put: <T>(path: string, data?: any, options?: ApiRequestInit) => apiFetch<T>(path, {
+    method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: data ? JSON.stringify(data) : undefined,
     ...options,
   }),
-  patch: <T>(path: string, data?: any, options?: RequestInit) => apiFetch<T>(path, {
+  patch: <T>(path: string, data?: any, options?: ApiRequestInit) => apiFetch<T>(path, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: data ? JSON.stringify(data) : undefined,
     ...options,
   }),
-  delete: <T>(path: string, options?: RequestInit) => apiFetch<T>(path, { method: 'DELETE', ...options }),
+  delete: <T>(path: string, options?: ApiRequestInit) => apiFetch<T>(path, { method: 'DELETE', ...options }),
 };


### PR DESCRIPTION
## Summary
- extend shared API helper with blob support and corrected filename regex
- route bulk asset export through API helper
- remove `any` usage in asset checkout via explicit typing

## Testing
- `TEST_BYPASS_AUTH=true go test -cover ./...` (warnings: `go: no such tool "covdata"` for some packages)


------
https://chatgpt.com/codex/tasks/task_e_68c135bcfdb883229c0258a65e16100a