### PR TITLE
Add email inbound/outbound tables and webhook support

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -60,6 +60,7 @@ import (
 	ticketspkg "github.com/mark3748/helpdesk-go/cmd/api/tickets"
 	userspkg "github.com/mark3748/helpdesk-go/cmd/api/users"
 	watcherspkg "github.com/mark3748/helpdesk-go/cmd/api/watchers"
+	webhookspkg "github.com/mark3748/helpdesk-go/cmd/api/webhooks"
 	rateln "github.com/mark3748/helpdesk-go/internal/ratelimit"
 )
 
@@ -805,6 +806,10 @@ func (a *App) mountAPI(rg *gin.RouterGroup) {
 	auth.GET("/metrics/manager", authpkg.RequireRole("manager", "admin"), metricspkg.Manager(a.core()))
 	auth.POST("/exports/tickets", authpkg.RequireRole("agent"), a.exportTicketsBridge)
 	auth.GET("/exports/tickets/:job_id", authpkg.RequireRole("agent"), a.exportTicketsStatus)
+
+	auth.GET("/webhooks", authpkg.RequireRole("admin"), webhookspkg.List(a.core()))
+	auth.POST("/webhooks", authpkg.RequireRole("admin"), webhookspkg.Create(a.core()))
+	auth.DELETE("/webhooks/:id", authpkg.RequireRole("admin"), webhookspkg.Delete(a.core()))
 
 	// Asset Management
 	auth.GET("/asset-categories", assetspkg.ListCategories(a.core()))

--- a/cmd/api/migrations/0019_email_inbound.sql
+++ b/cmd/api/migrations/0019_email_inbound.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+create table if not exists email_inbound (
+    id uuid primary key default gen_random_uuid(),
+    raw_store_key text not null,
+    parsed_json jsonb not null,
+    message_id text unique,
+    status text not null default 'new',
+    ticket_id uuid references tickets(id),
+    created_at timestamptz not null default now()
+);
+
+-- +goose Down
+drop table if exists email_inbound;

--- a/cmd/api/migrations/0020_email_outbound.sql
+++ b/cmd/api/migrations/0020_email_outbound.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+create table if not exists email_outbound (
+    id uuid primary key default gen_random_uuid(),
+    to_addr text not null,
+    subject text,
+    body_html text,
+    status text not null,
+    retries int not null default 0,
+    ticket_id uuid references tickets(id),
+    created_at timestamptz not null default now()
+);
+
+-- +goose Down
+drop table if exists email_outbound;

--- a/cmd/api/migrations/0021_webhooks.sql
+++ b/cmd/api/migrations/0021_webhooks.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+create table if not exists webhooks (
+    id uuid primary key default gen_random_uuid(),
+    target_url text not null,
+    event_mask int not null default 0,
+    secret text,
+    active boolean not null default true,
+    created_at timestamptz not null default now()
+);
+
+-- +goose Down
+drop table if exists webhooks;

--- a/cmd/api/webhooks/webhooks.go
+++ b/cmd/api/webhooks/webhooks.go
@@ -1,0 +1,83 @@
+package webhooks
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	app "github.com/mark3748/helpdesk-go/cmd/api/app"
+)
+
+type webhookReq struct {
+	TargetURL string `json:"target_url" binding:"required"`
+	EventMask int    `json:"event_mask"`
+	Secret    string `json:"secret"`
+	Active    bool   `json:"active"`
+}
+
+// List returns all webhook subscriptions.
+func List(a *app.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if a.DB == nil {
+			c.JSON(http.StatusOK, []map[string]any{})
+			return
+		}
+		ctx := c.Request.Context()
+		rows, err := a.DB.Query(ctx, `select id, target_url, event_mask, secret, active from webhooks order by target_url`)
+		if err != nil {
+			app.AbortError(c, http.StatusInternalServerError, "db_query_failed", "database query failed", nil)
+			return
+		}
+		defer rows.Close()
+		out := []map[string]any{}
+		for rows.Next() {
+			var id, url, secret string
+			var mask int
+			var active bool
+			if err := rows.Scan(&id, &url, &mask, &secret, &active); err == nil {
+				out = append(out, map[string]any{
+					"id":         id,
+					"target_url": url,
+					"event_mask": mask,
+					"secret":     secret,
+					"active":     active,
+				})
+			}
+		}
+		c.JSON(http.StatusOK, out)
+	}
+}
+
+// Create inserts a new webhook subscription.
+func Create(a *app.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var in webhookReq
+		if err := c.ShouldBindJSON(&in); err != nil {
+			app.AbortError(c, http.StatusBadRequest, "invalid_body", "invalid request body", map[string]string{"target_url": "required"})
+			return
+		}
+		if a.DB != nil {
+			ctx := c.Request.Context()
+			if _, err := a.DB.Exec(ctx, `insert into webhooks (target_url, event_mask, secret, active) values ($1,$2,$3,$4)`, in.TargetURL, in.EventMask, in.Secret, in.Active); err != nil {
+				app.AbortError(c, http.StatusInternalServerError, "db_exec_failed", "database exec failed", nil)
+				return
+			}
+		}
+		c.Status(http.StatusCreated)
+	}
+}
+
+// Delete removes a webhook subscription by ID.
+func Delete(a *app.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if a.DB != nil {
+			ctx := c.Request.Context()
+			id := c.Param("id")
+			if _, err := a.DB.Exec(ctx, `delete from webhooks where id=$1`, id); err != nil {
+				app.AbortError(c, http.StatusInternalServerError, "db_exec_failed", "database exec failed", nil)
+				return
+			}
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	}
+}

--- a/cmd/api/webhooks/webhooks_test.go
+++ b/cmd/api/webhooks/webhooks_test.go
@@ -1,0 +1,141 @@
+package webhooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+)
+
+type fakeDB struct{ hooks map[string]hook }
+
+type hook struct {
+	ID        string
+	TargetURL string
+	EventMask int
+	Secret    string
+	Active    bool
+}
+
+func (db *fakeDB) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	fr := &fakeRows{}
+	for _, h := range db.hooks {
+		fr.list = append(fr.list, h)
+	}
+	return fr, nil
+}
+
+func (db *fakeDB) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row { return fakeRow{} }
+
+func (db *fakeDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	if db.hooks == nil {
+		db.hooks = map[string]hook{}
+	}
+	s := strings.ToLower(sql)
+	if strings.HasPrefix(s, "insert") {
+		id := "1"
+		db.hooks[id] = hook{ID: id, TargetURL: args[0].(string), EventMask: args[1].(int), Secret: args[2].(string), Active: args[3].(bool)}
+	} else if strings.HasPrefix(s, "delete") {
+		id := args[0].(string)
+		delete(db.hooks, id)
+	}
+	return pgconn.CommandTag{}, nil
+}
+
+func (db *fakeDB) Begin(ctx context.Context) (pgx.Tx, error) { return nil, nil }
+
+type fakeRows struct {
+	list []hook
+	i    int
+}
+
+func (r *fakeRows) Close()                                       {}
+func (r *fakeRows) Err() error                                   { return nil }
+func (r *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeRows) RawValues() [][]byte                          { return nil }
+func (r *fakeRows) Values() ([]any, error)                       { return nil, nil }
+func (r *fakeRows) Conn() *pgx.Conn                              { return nil }
+func (r *fakeRows) Next() bool {
+	if r.i >= len(r.list) {
+		return false
+	}
+	r.i++
+	return true
+}
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.i == 0 || r.i > len(r.list) {
+		return nil
+	}
+	h := r.list[r.i-1]
+	if p, ok := dest[0].(*string); ok {
+		*p = h.ID
+	}
+	if p, ok := dest[1].(*string); ok {
+		*p = h.TargetURL
+	}
+	if p, ok := dest[2].(*int); ok {
+		*p = h.EventMask
+	}
+	if p, ok := dest[3].(*string); ok {
+		*p = h.Secret
+	}
+	if p, ok := dest[4].(*bool); ok {
+		*p = h.Active
+	}
+	return nil
+}
+
+type fakeRow struct{}
+
+func (fakeRow) Scan(dest ...any) error { return pgx.ErrNoRows }
+
+func TestWebhookHandlers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := &fakeDB{}
+	cfg := apppkg.Config{Env: "test", TestBypassAuth: true}
+	a := apppkg.NewApp(cfg, db, nil, nil, nil)
+	a.R.GET("/webhooks", authpkg.Middleware(a), List(a))
+	a.R.POST("/webhooks", authpkg.Middleware(a), Create(a))
+	a.R.DELETE("/webhooks/:id", authpkg.Middleware(a), Delete(a))
+
+	body := bytes.NewBufferString(`{"target_url":"https://example.com","event_mask":1,"secret":"s","active":true}`)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/webhooks", body)
+	req.Header.Set("Content-Type", "application/json")
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/webhooks", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || out[0]["target_url"].(string) != "https://example.com" {
+		t.Fatalf("unexpected list: %v", out)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodDelete, "/webhooks/1", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}

--- a/cmd/worker/email_security_test.go
+++ b/cmd/worker/email_security_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 )
 
@@ -255,21 +256,21 @@ func TestSendEmailSecurityValidation(t *testing.T) {
 	}
 
 	// This should fail due to invalid From address
-	err := sendEmail(config, job)
+	err := sendEmail(context.Background(), nil, config, job)
 	if err == nil {
 		t.Error("Expected sendEmail to fail with invalid From address, but it succeeded")
 	}
 
 	// Test with invalid To address
 	config.SMTPFrom = "valid@example.com"
-	err = sendEmail(config, job)
+	err = sendEmail(context.Background(), nil, config, job)
 	if err == nil {
 		t.Error("Expected sendEmail to fail with header injection in To address, but it succeeded")
 	}
 
 	// Test with valid addresses (this will fail due to missing template, but validation should pass)
 	job.To = "user@example.com"
-	err = sendEmail(config, job)
+	err = sendEmail(context.Background(), nil, config, job)
 	// We expect an error due to missing template, but not due to email validation
 	if err != nil && err.Error() == "invalid To address: invalid email address format: user@example.comBcc: attacker@evil.com" {
 		t.Error("Email validation should have passed for clean email address")

--- a/cmd/worker/worker_test.go
+++ b/cmd/worker/worker_test.go
@@ -8,7 +8,11 @@ import (
 	"testing"
 
 	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/redis/go-redis/v9"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
 )
 
 func TestSendEmail(t *testing.T) {
@@ -31,7 +35,8 @@ func TestSendEmail(t *testing.T) {
 
 	c := Config{SMTPHost: "smtp", SMTPPort: "25", SMTPFrom: "from@example.com"}
 	j := EmailJob{To: "to@example.com", Template: "ticket_created", Data: struct{ Number int }{1}}
-	if err := sendEmail(c, j); err != nil {
+	db := &execDB{}
+	if err := sendEmail(context.Background(), db, c, j); err != nil {
 		t.Fatalf("sendEmail: %v", err)
 	}
 	if captured.addr != "smtp:25" || captured.from != "from@example.com" || captured.to[0] != "to@example.com" {
@@ -39,6 +44,9 @@ func TestSendEmail(t *testing.T) {
 	}
 	if !strings.Contains(captured.msg, "Ticket created") {
 		t.Fatalf("unexpected message: %s", captured.msg)
+	}
+	if db.lastSQL == "" || !strings.Contains(strings.ToLower(db.lastSQL), "email_outbound") {
+		t.Fatalf("expected insert into email_outbound, got %q", db.lastSQL)
 	}
 }
 
@@ -56,14 +64,34 @@ func TestProcessQueueJob(t *testing.T) {
 		t.Fatalf("lpush: %v", err)
 	}
 	called := false
-	send := func(c Config, j EmailJob) error {
+	send := func(ctx context.Context, db apppkg.DB, c Config, j EmailJob) error {
 		called = true
 		return nil
 	}
-	if err := processQueueJob(context.Background(), c, rdb, send); err != nil {
+	if err := processQueueJob(context.Background(), &execDB{}, c, rdb, send); err != nil {
 		t.Fatalf("processQueueJob: %v", err)
 	}
 	if !called {
 		t.Fatalf("sendEmail not called")
 	}
 }
+
+type execDB struct {
+	lastSQL  string
+	lastArgs []any
+}
+
+func (f *execDB) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	return nil, nil
+}
+func (f *execDB) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row { return execRow{} }
+func (f *execDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	f.lastSQL = sql
+	f.lastArgs = args
+	return pgconn.CommandTag{}, nil
+}
+func (f *execDB) Begin(ctx context.Context) (pgx.Tx, error) { return nil, nil }
+
+type execRow struct{}
+
+func (execRow) Scan(dest ...any) error { return pgx.ErrNoRows }


### PR DESCRIPTION
## Summary
- add migrations for email_inbound, email_outbound, and webhooks tables
- expose CRUD endpoints for webhook subscriptions
- record outbound email send status in worker

## Testing
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c30db1b6bc8322959e251ad55bb900