### PR TITLE
fix: gate SLA clock reset on resume

### DIFF
--- a/cmd/api/tickets/tickets.go
+++ b/cmd/api/tickets/tickets.go
@@ -694,7 +694,7 @@ func Update(a *app.App) gin.HandlerFunc {
 			if pause {
 				reason = normStatus
 			}
-			_, _ = a.DB.Exec(c.Request.Context(), `update ticket_sla_clocks set paused=$1, reason=$2, last_started_at=case when $1 then last_started_at else now() end where ticket_id=$3`, pause, reason, c.Param("id"))
+			_, _ = a.DB.Exec(c.Request.Context(), `update ticket_sla_clocks set paused=$1, reason=$2, last_started_at=case when paused and not $1 then now() else last_started_at end where ticket_id=$3`, pause, reason, c.Param("id"))
 		}
 		var t Ticket
 		var assignee *string

--- a/cmd/api/tickets/tickets_test.go
+++ b/cmd/api/tickets/tickets_test.go
@@ -168,6 +168,9 @@ func TestUpdateSLAPauseResume(t *testing.T) {
 			if !strings.Contains(sql, "ticket_sla_clocks") {
 				t.Fatalf("expected sla update, got %s", sql)
 			}
+			if !strings.Contains(sql, "last_started_at=case when paused and not $1 then now() else last_started_at end") {
+				t.Fatalf("missing last_started_at guard in %s", sql)
+			}
 			args := db.execArgs[1]
 			if args[0] != tt.pause {
 				t.Fatalf("pause arg = %v, want %v", args[0], tt.pause)


### PR DESCRIPTION
## Summary
- avoid resetting SLA timer when moving between active ticket statuses
- assert SLA clock reset logic in ticket handler tests

## Testing
- `go test -cover ./...` *(fails: go: no such tool "covdata")*
- `go test ./cmd/worker -run TestUpdateSLAClocksPaused -v`


------
https://chatgpt.com/codex/tasks/task_e_68c31f2c5ac8832285252e761cbdfa24