### PR TITLE
api: add teams, slas, kb search and email webhook

### DIFF
--- a/cmd/api/kb/kb.go
+++ b/cmd/api/kb/kb.go
@@ -1,0 +1,23 @@
+package kb
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	kbsvc "github.com/mark3748/helpdesk-go/internal/kb"
+)
+
+// Search returns knowledge-base articles matching the query parameter `q`.
+func Search(a *apppkg.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		q := c.Query("q")
+		arts, err := kbsvc.Search(c.Request.Context(), a.DB, q)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, arts)
+	}
+}

--- a/cmd/api/kb/kb_test.go
+++ b/cmd/api/kb/kb_test.go
@@ -1,0 +1,93 @@
+package kb
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+)
+
+type fakeDB struct{ rows []article }
+
+type article struct {
+	id, slug, title, body string
+}
+
+func (db *fakeDB) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	r := &fakeRows{rows: db.rows}
+	return r, nil
+}
+func (db *fakeDB) QueryRow(context.Context, string, ...any) pgx.Row { return nil }
+func (db *fakeDB) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+func (db *fakeDB) Begin(context.Context) (pgx.Tx, error) { return nil, nil }
+
+type fakeRows struct {
+	rows []article
+	i    int
+}
+
+func (r *fakeRows) Close()                                       {}
+func (r *fakeRows) Err() error                                   { return nil }
+func (r *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeRows) RawValues() [][]byte                          { return nil }
+func (r *fakeRows) Values() ([]any, error)                       { return nil, nil }
+func (r *fakeRows) Conn() *pgx.Conn                              { return nil }
+func (r *fakeRows) Next() bool {
+	if r.i >= len(r.rows) {
+		return false
+	}
+	r.i++
+	return true
+}
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.i == 0 || r.i > len(r.rows) {
+		return pgx.ErrNoRows
+	}
+	row := r.rows[r.i-1]
+	if p, ok := dest[0].(*string); ok {
+		*p = row.id
+	}
+	if p, ok := dest[1].(*string); ok {
+		*p = row.slug
+	}
+	if p, ok := dest[2].(*string); ok {
+		*p = row.title
+	}
+	if p, ok := dest[3].(*string); ok {
+		*p = row.body
+	}
+	return nil
+}
+
+func TestSearch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := &fakeDB{rows: []article{{"1", "slug", "Title", "Body"}}}
+	cfg := apppkg.Config{Env: "test", TestBypassAuth: true}
+	a := apppkg.NewApp(cfg, db, nil, nil, nil)
+	a.R.GET("/kb", authpkg.Middleware(a), Search(a))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/kb?q=x", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || out[0]["slug"].(string) != "slug" {
+		t.Fatalf("unexpected output: %v", out)
+	}
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -54,10 +54,13 @@ import (
 	appevents "github.com/mark3748/helpdesk-go/cmd/api/events"
 	exportspkg "github.com/mark3748/helpdesk-go/cmd/api/exports"
 	handlers "github.com/mark3748/helpdesk-go/cmd/api/handlers"
+	kbpkg "github.com/mark3748/helpdesk-go/cmd/api/kb"
 	metricspkg "github.com/mark3748/helpdesk-go/cmd/api/metrics"
 	problemspkg "github.com/mark3748/helpdesk-go/cmd/api/problems"
 	releasespkg "github.com/mark3748/helpdesk-go/cmd/api/releases"
 	roles "github.com/mark3748/helpdesk-go/cmd/api/roles"
+	slaspkg "github.com/mark3748/helpdesk-go/cmd/api/slas"
+	teamspkg "github.com/mark3748/helpdesk-go/cmd/api/teams"
 	ticketspkg "github.com/mark3748/helpdesk-go/cmd/api/tickets"
 	userspkg "github.com/mark3748/helpdesk-go/cmd/api/users"
 	watcherspkg "github.com/mark3748/helpdesk-go/cmd/api/watchers"
@@ -746,6 +749,8 @@ func (a *App) mountAPI(rg *gin.RouterGroup) {
 		}
 	}
 
+	rg.POST("/webhooks/email-inbound", webhookspkg.EmailInbound(a.core()))
+
 	// Use an empty subpath to avoid introducing a double slash (e.g.,
 	// "/api//me"). The UI expects endpoints like "/api/me".
 	auth := rg.Group("")
@@ -777,6 +782,10 @@ func (a *App) mountAPI(rg *gin.RouterGroup) {
 	auth.GET("/requesters/:id", a.getRequester)
 	auth.POST("/requesters", authpkg.RequireRole("agent", "manager"), a.createRequester)
 	auth.PATCH("/requesters/:id", authpkg.RequireRole("agent", "manager"), a.updateRequester)
+
+	auth.GET("/teams", teamspkg.List(a.core()))
+	auth.GET("/slas", slaspkg.List(a.core()))
+	auth.GET("/kb", kbpkg.Search(a.core()))
 
 	// Tickets
 	auth.GET("/tickets", ticketspkg.List(a.core()))

--- a/cmd/api/migrations/0022_seed_teams_slas.sql
+++ b/cmd/api/migrations/0022_seed_teams_slas.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+insert into teams (name) values ('Support'), ('IT') on conflict do nothing;
+insert into sla_policies (name, priority, response_target_mins, resolution_target_mins, update_cadence_mins) values
+    ('Standard', 3, 60, 1440, 30),
+    ('High Priority', 1, 15, 480, 15)
+on conflict do nothing;
+
+-- +goose Down
+delete from sla_policies where name in ('Standard', 'High Priority');
+delete from teams where name in ('Support', 'IT');

--- a/cmd/api/migrations/0023_kb_articles.sql
+++ b/cmd/api/migrations/0023_kb_articles.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+create table if not exists kb_articles (
+    id uuid primary key default gen_random_uuid(),
+    slug text unique not null,
+    title text not null,
+    body_md text not null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+-- +goose Down
+drop table if exists kb_articles;

--- a/cmd/api/slas/slas.go
+++ b/cmd/api/slas/slas.go
@@ -1,0 +1,22 @@
+package slas
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	slapkg "github.com/mark3748/helpdesk-go/internal/sla"
+)
+
+// List returns SLA policies.
+func List(a *apppkg.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		slas, err := slapkg.ListPolicies(c.Request.Context(), a.DB)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, slas)
+	}
+}

--- a/cmd/api/slas/slas_test.go
+++ b/cmd/api/slas/slas_test.go
@@ -1,0 +1,105 @@
+package slas
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+)
+
+type fakeDB struct{ rows []slapolicy }
+
+type slapolicy struct {
+	id         string
+	name       string
+	priority   int
+	response   int
+	resolution int
+	update     *int
+}
+
+func (db *fakeDB) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	r := &fakeRows{rows: db.rows}
+	return r, nil
+}
+func (db *fakeDB) QueryRow(context.Context, string, ...any) pgx.Row { return nil }
+func (db *fakeDB) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+func (db *fakeDB) Begin(context.Context) (pgx.Tx, error) { return nil, nil }
+
+type fakeRows struct {
+	rows []slapolicy
+	i    int
+}
+
+func (r *fakeRows) Close()                                       {}
+func (r *fakeRows) Err() error                                   { return nil }
+func (r *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeRows) RawValues() [][]byte                          { return nil }
+func (r *fakeRows) Values() ([]any, error)                       { return nil, nil }
+func (r *fakeRows) Conn() *pgx.Conn                              { return nil }
+func (r *fakeRows) Next() bool {
+	if r.i >= len(r.rows) {
+		return false
+	}
+	r.i++
+	return true
+}
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.i == 0 || r.i > len(r.rows) {
+		return pgx.ErrNoRows
+	}
+	row := r.rows[r.i-1]
+	if p, ok := dest[0].(*string); ok {
+		*p = row.id
+	}
+	if p, ok := dest[1].(*string); ok {
+		*p = row.name
+	}
+	if p, ok := dest[2].(*int); ok {
+		*p = row.priority
+	}
+	if p, ok := dest[3].(*int); ok {
+		*p = row.response
+	}
+	if p, ok := dest[4].(*int); ok {
+		*p = row.resolution
+	}
+	if p, ok := dest[5].(**int); ok {
+		*p = row.update
+	}
+	return nil
+}
+
+func TestList(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	up := 30
+	db := &fakeDB{rows: []slapolicy{{"1", "P1", 1, 10, 20, &up}}}
+	cfg := apppkg.Config{Env: "test", TestBypassAuth: true}
+	a := apppkg.NewApp(cfg, db, nil, nil, nil)
+	a.R.GET("/slas", authpkg.Middleware(a), List(a))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/slas", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || out[0]["name"].(string) != "P1" {
+		t.Fatalf("unexpected output: %v", out)
+	}
+}

--- a/cmd/api/teams/teams.go
+++ b/cmd/api/teams/teams.go
@@ -1,0 +1,22 @@
+package teams
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	teamsvc "github.com/mark3748/helpdesk-go/internal/teams"
+)
+
+// List returns all teams.
+func List(a *apppkg.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		teams, err := teamsvc.List(c.Request.Context(), a.DB)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, teams)
+	}
+}

--- a/cmd/api/teams/teams_test.go
+++ b/cmd/api/teams/teams_test.go
@@ -1,0 +1,83 @@
+package teams
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+)
+
+type fakeDB struct{ rows []struct{ id, name string } }
+
+func (db *fakeDB) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	r := &fakeRows{rows: db.rows}
+	return r, nil
+}
+func (db *fakeDB) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row { return nil }
+func (db *fakeDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+func (db *fakeDB) Begin(ctx context.Context) (pgx.Tx, error) { return nil, nil }
+
+type fakeRows struct {
+	rows []struct{ id, name string }
+	i    int
+}
+
+func (r *fakeRows) Close()                                       {}
+func (r *fakeRows) Err() error                                   { return nil }
+func (r *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeRows) RawValues() [][]byte                          { return nil }
+func (r *fakeRows) Values() ([]any, error)                       { return nil, nil }
+func (r *fakeRows) Conn() *pgx.Conn                              { return nil }
+func (r *fakeRows) Next() bool {
+	if r.i >= len(r.rows) {
+		return false
+	}
+	r.i++
+	return true
+}
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.i == 0 || r.i > len(r.rows) {
+		return pgx.ErrNoRows
+	}
+	row := r.rows[r.i-1]
+	if p, ok := dest[0].(*string); ok {
+		*p = row.id
+	}
+	if p, ok := dest[1].(*string); ok {
+		*p = row.name
+	}
+	return nil
+}
+
+func TestList(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := &fakeDB{rows: []struct{ id, name string }{{"1", "A"}, {"2", "B"}}}
+	cfg := apppkg.Config{Env: "test", TestBypassAuth: true}
+	a := apppkg.NewApp(cfg, db, nil, nil, nil)
+	a.R.GET("/teams", authpkg.Middleware(a), List(a))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/teams", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var out []map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 2 || out[0]["id"] != "1" {
+		t.Fatalf("unexpected output: %v", out)
+	}
+}

--- a/cmd/api/webhooks/email_inbound.go
+++ b/cmd/api/webhooks/email_inbound.go
@@ -1,0 +1,33 @@
+package webhooks
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+)
+
+type EmailInboundReq struct {
+	RawStoreKey string         `json:"raw_store_key" binding:"required"`
+	ParsedJSON  map[string]any `json:"parsed_json" binding:"required"`
+	MessageID   string         `json:"message_id"`
+}
+
+// EmailInbound accepts inbound email webhooks and stores payloads for later processing.
+func EmailInbound(a *apppkg.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var in EmailInboundReq
+		if err := c.ShouldBindJSON(&in); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json"})
+			return
+		}
+		if a.DB != nil {
+			if _, err := a.DB.Exec(c.Request.Context(), `insert into email_inbound (raw_store_key, parsed_json, message_id) values ($1,$2,$3)`, in.RawStoreKey, in.ParsedJSON, in.MessageID); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+		}
+		c.Status(http.StatusAccepted)
+	}
+}

--- a/cmd/api/webhooks/email_inbound_test.go
+++ b/cmd/api/webhooks/email_inbound_test.go
@@ -1,0 +1,52 @@
+package webhooks
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+)
+
+type fakeDBInbound struct {
+	sql  string
+	args []any
+}
+
+func (db *fakeDBInbound) Query(context.Context, string, ...any) (pgx.Rows, error) { return nil, nil }
+func (db *fakeDBInbound) QueryRow(context.Context, string, ...any) pgx.Row        { return nil }
+func (db *fakeDBInbound) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	db.sql = sql
+	db.args = args
+	return pgconn.CommandTag{}, nil
+}
+func (db *fakeDBInbound) Begin(context.Context) (pgx.Tx, error) { return nil, nil }
+
+func TestEmailInbound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := &fakeDBInbound{}
+	cfg := apppkg.Config{Env: "test"}
+	a := apppkg.NewApp(cfg, db, nil, nil, nil)
+	a.R.POST("/webhooks/email-inbound", EmailInbound(a))
+
+	body := bytes.NewBufferString(`{"raw_store_key":"k","parsed_json":{},"message_id":"m"}`)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/email-inbound", body)
+	req.Header.Set("Content-Type", "application/json")
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rr.Code)
+	}
+	if db.sql == "" || len(db.args) != 3 {
+		t.Fatalf("exec not called properly")
+	}
+	if db.args[0].(string) != "k" {
+		t.Fatalf("unexpected arg: %v", db.args)
+	}
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -21,6 +21,10 @@ tags:
   - name: Exports
   - name: Events
   - name: Assets
+  - name: Teams
+  - name: SLAs
+  - name: KnowledgeBase
+  - name: Webhooks
 security:
   - bearerAuth: []
   - cookieAuth: []
@@ -448,14 +452,46 @@ components:
           anyOf:
             - $ref: '#/components/schemas/Asset'
             - type: "null"
-        assigned_user: 
+        assigned_user:
           anyOf:
             - $ref: '#/components/schemas/AssetUser'
             - type: "null"
-        assigned_by: 
+        assigned_by:
           anyOf:
             - $ref: '#/components/schemas/AssetUser'
             - type: "null"
+    Team:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        name: { type: string }
+      required: [id, name]
+    SLA:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        name: { type: string }
+        priority: { type: integer }
+        response_target_mins: { type: integer }
+        resolution_target_mins: { type: integer }
+        update_cadence_mins:
+          type: [integer, "null"]
+      required: [id, name, priority, response_target_mins, resolution_target_mins]
+    KBArticle:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        slug: { type: string }
+        title: { type: string }
+        body_md: { type: string }
+      required: [id, slug, title, body_md]
+    EmailInboundPayload:
+      type: object
+      properties:
+        raw_store_key: { type: string }
+        parsed_json: { type: object }
+        message_id: { type: string }
+      required: [raw_store_key, parsed_json]
 paths:
   # Asset Management Endpoints
   /asset-categories:
@@ -1740,4 +1776,73 @@ paths:
       security:
         - bearerAuth: []
         - cookieAuth: []
+
+  /teams:
+    get:
+      operationId: listTeams
+      tags: [Teams]
+      summary: List teams
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Team' }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+
+  /slas:
+    get:
+      operationId: listSLAs
+      tags: [SLAs]
+      summary: List SLA policies
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/SLA' }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+
+  /kb:
+    get:
+      operationId: searchKB
+      tags: [KnowledgeBase]
+      summary: Search knowledge base articles
+      parameters:
+        - in: query
+          name: q
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/KBArticle' }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+
+  /webhooks/email-inbound:
+    post:
+      operationId: emailInbound
+      tags: [Webhooks]
+      summary: Accept inbound email webhook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/EmailInboundPayload' }
+      responses:
+        '202': { description: Accepted }
+      security: []
 

--- a/internal/kb/kb.go
+++ b/internal/kb/kb.go
@@ -1,0 +1,37 @@
+package kb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type DB interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+type Article struct {
+	ID     string `json:"id"`
+	Slug   string `json:"slug"`
+	Title  string `json:"title"`
+	BodyMD string `json:"body_md"`
+}
+
+func Search(ctx context.Context, db DB, q string) ([]Article, error) {
+	q = strings.TrimSpace(q)
+	rows, err := db.Query(ctx, `select id::text, slug, title, body_md from kb_articles where title ilike '%'||$1||'%' or body_md ilike '%'||$1||'%' order by title limit 20`, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []Article{}
+	for rows.Next() {
+		var a Article
+		if err := rows.Scan(&a.ID, &a.Slug, &a.Title, &a.BodyMD); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}

--- a/internal/sla/policies.go
+++ b/internal/sla/policies.go
@@ -1,0 +1,39 @@
+package sla
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type policyDB interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+// Policy represents an SLA policy.
+type Policy struct {
+	ID                   string `json:"id"`
+	Name                 string `json:"name"`
+	Priority             int    `json:"priority"`
+	ResponseTargetMins   int    `json:"response_target_mins"`
+	ResolutionTargetMins int    `json:"resolution_target_mins"`
+	UpdateCadenceMins    *int   `json:"update_cadence_mins,omitempty"`
+}
+
+// ListPolicies returns all SLA policies.
+func ListPolicies(ctx context.Context, db policyDB) ([]Policy, error) {
+	rows, err := db.Query(ctx, `select id::text, name, priority, response_target_mins, resolution_target_mins, update_cadence_mins from sla_policies order by priority`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []Policy{}
+	for rows.Next() {
+		var p Policy
+		if err := rows.Scan(&p.ID, &p.Name, &p.Priority, &p.ResponseTargetMins, &p.ResolutionTargetMins, &p.UpdateCadenceMins); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}

--- a/internal/teams/teams.go
+++ b/internal/teams/teams.go
@@ -1,0 +1,33 @@
+package teams
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type DB interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+type Team struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func List(ctx context.Context, db DB) ([]Team, error) {
+	rows, err := db.Query(ctx, `select id::text, name from teams order by name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Team
+	for rows.Next() {
+		var t Team
+		if err := rows.Scan(&t.ID, &t.Name); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}

--- a/web/internal/src/types/openapi.ts
+++ b/web/internal/src/types/openapi.ts
@@ -2137,6 +2137,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/teams": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List teams */
+        get: operations["listTeams"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/slas": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List SLA policies */
+        get: operations["listSLAs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/kb": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Search knowledge base articles */
+        get: operations["searchKB"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/webhooks/email-inbound": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Accept inbound email webhook */
+        post: operations["emailInbound"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2487,6 +2555,32 @@ export interface components {
             asset?: components["schemas"]["Asset"] | null;
             assigned_user?: components["schemas"]["AssetUser"] | null;
             assigned_by?: components["schemas"]["AssetUser"] | null;
+        };
+        Team: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+        };
+        SLA: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            priority: number;
+            response_target_mins: number;
+            resolution_target_mins: number;
+            update_cadence_mins?: number | null;
+        };
+        KBArticle: {
+            /** Format: uuid */
+            id: string;
+            slug: string;
+            title: string;
+            body_md: string;
+        };
+        EmailInboundPayload: {
+            raw_store_key: string;
+            parsed_json: Record<string, never>;
+            message_id?: string;
         };
     };
     responses: never;
@@ -3162,6 +3256,90 @@ export interface operations {
             };
             /** @description Server Error */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listTeams: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Team"][];
+                };
+            };
+        };
+    };
+    listSLAs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SLA"][];
+                };
+            };
+        };
+    };
+    searchKB: {
+        parameters: {
+            query?: {
+                q?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KBArticle"][];
+                };
+            };
+        };
+    };
+    emailInbound: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EmailInboundPayload"];
+            };
+        };
+        responses: {
+            /** @description Accepted */
+            202: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/web/requester/src/types/openapi.ts
+++ b/web/requester/src/types/openapi.ts
@@ -1123,6 +1123,22 @@ export interface paths {
     /** Check export job status */
     get: operations["getExportJobStatus"];
   };
+  "/teams": {
+    /** List teams */
+    get: operations["listTeams"];
+  };
+  "/slas": {
+    /** List SLA policies */
+    get: operations["listSLAs"];
+  };
+  "/kb": {
+    /** Search knowledge base articles */
+    get: operations["searchKB"];
+  };
+  "/webhooks/email-inbound": {
+    /** Accept inbound email webhook */
+    post: operations["emailInbound"];
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -1386,6 +1402,7 @@ export interface components {
       location?: string;
       custom_fields?: Record<string, never>;
     };
+    notes: string;
     AssignAssetRequest: {
       /** Format: uuid */
       assigned_to_user_id?: string | null;
@@ -1474,6 +1491,32 @@ export interface components {
       asset?: components["schemas"]["Asset"] | null;
       assigned_user?: components["schemas"]["AssetUser"] | null;
       assigned_by?: components["schemas"]["AssetUser"] | null;
+    };
+    Team: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+    };
+    SLA: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+      priority: number;
+      response_target_mins: number;
+      resolution_target_mins: number;
+      update_cadence_mins?: number | null;
+    };
+    KBArticle: {
+      /** Format: uuid */
+      id: string;
+      slug: string;
+      title: string;
+      body_md: string;
+    };
+    EmailInboundPayload: {
+      raw_store_key: string;
+      parsed_json: Record<string, never>;
+      message_id?: string;
     };
   };
   responses: never;
@@ -1933,6 +1976,58 @@ export interface operations {
       };
       /** @description Server Error */
       500: {
+        content: never;
+      };
+    };
+  };
+  /** List teams */
+  listTeams: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Team"][];
+        };
+      };
+    };
+  };
+  /** List SLA policies */
+  listSLAs: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SLA"][];
+        };
+      };
+    };
+  };
+  /** Search knowledge base articles */
+  searchKB: {
+    parameters: {
+      query?: {
+        q?: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["KBArticle"][];
+        };
+      };
+    };
+  };
+  /** Accept inbound email webhook */
+  emailInbound: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["EmailInboundPayload"];
+      };
+    };
+    responses: {
+      /** @description Accepted */
+      202: {
         content: never;
       };
     };


### PR DESCRIPTION
## Summary
- list teams and SLA policies via new API endpoints
- search knowledge base articles
- accept inbound email webhooks

## Testing
- `make gen-types`
- `TEST_BYPASS_AUTH=true go test -cover ./...` *(fails: go: no such tool "covdata")*
- `TEST_BYPASS_AUTH=true go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68c3239c838c8322bb11c076bfbc087b