### PR TITLE
api: add knowledge base article CRUD and requester fetch

### DIFF
--- a/cmd/api/kb/kb.go
+++ b/cmd/api/kb/kb.go
@@ -21,3 +21,70 @@ func Search(a *apppkg.App) gin.HandlerFunc {
 		c.JSON(http.StatusOK, arts)
 	}
 }
+
+// Get returns a single article by slug.
+func Get(a *apppkg.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		art, err := kbsvc.Get(c.Request.Context(), a.DB, c.Param("slug"))
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusOK, art)
+	}
+}
+
+// Create inserts a new knowledge base article.
+func Create(a *apppkg.App) gin.HandlerFunc {
+	type in struct {
+		Slug   string `json:"slug"`
+		Title  string `json:"title"`
+		BodyMD string `json:"body_md"`
+	}
+	return func(c *gin.Context) {
+		var req in
+		if err := c.ShouldBindJSON(&req); err != nil || req.Slug == "" || req.Title == "" || req.BodyMD == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json"})
+			return
+		}
+		art, err := kbsvc.Create(c.Request.Context(), a.DB, kbsvc.Article{Slug: req.Slug, Title: req.Title, BodyMD: req.BodyMD})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusCreated, art)
+	}
+}
+
+// Update modifies an existing article identified by slug.
+func Update(a *apppkg.App) gin.HandlerFunc {
+	type in struct {
+		Slug   string `json:"slug"`
+		Title  string `json:"title"`
+		BodyMD string `json:"body_md"`
+	}
+	return func(c *gin.Context) {
+		var req in
+		if err := c.ShouldBindJSON(&req); err != nil || req.Slug == "" || req.Title == "" || req.BodyMD == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json"})
+			return
+		}
+		art, err := kbsvc.Update(c.Request.Context(), a.DB, c.Param("slug"), kbsvc.Article{Slug: req.Slug, Title: req.Title, BodyMD: req.BodyMD})
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusOK, art)
+	}
+}
+
+// Delete removes an article by slug.
+func Delete(a *apppkg.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if err := kbsvc.Delete(c.Request.Context(), a.DB, c.Param("slug")); err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.Status(http.StatusNoContent)
+	}
+}

--- a/cmd/api/kb/kb_test.go
+++ b/cmd/api/kb/kb_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -22,14 +23,80 @@ type article struct {
 }
 
 func (db *fakeDB) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
-	r := &fakeRows{rows: db.rows}
-	return r, nil
+	return &fakeRows{rows: db.rows}, nil
 }
-func (db *fakeDB) QueryRow(context.Context, string, ...any) pgx.Row { return nil }
-func (db *fakeDB) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+func (db *fakeDB) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	switch {
+	case strings.HasPrefix(sql, "insert"):
+		a := article{"1", args[0].(string), args[1].(string), args[2].(string)}
+		db.rows = append(db.rows, a)
+		return &fakeRow{a: a}
+	case strings.HasPrefix(sql, "select"):
+		slug := args[0].(string)
+		for _, r := range db.rows {
+			if r.slug == slug {
+				return &fakeRow{a: r}
+			}
+		}
+		return &fakeRow{err: pgx.ErrNoRows}
+	case strings.HasPrefix(sql, "update"):
+		slug := args[3].(string)
+		for i, r := range db.rows {
+			if r.slug == slug {
+				db.rows[i].slug = args[0].(string)
+				db.rows[i].title = args[1].(string)
+				db.rows[i].body = args[2].(string)
+				return &fakeRow{a: db.rows[i]}
+			}
+		}
+		return &fakeRow{err: pgx.ErrNoRows}
+	}
+	return &fakeRow{err: pgx.ErrNoRows}
+}
+func (db *fakeDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	if strings.HasPrefix(sql, "delete") {
+		slug := args[0].(string)
+		for i, r := range db.rows {
+			if r.slug == slug {
+				db.rows = append(db.rows[:i], db.rows[i+1:]...)
+				return pgconn.CommandTag{}, nil
+			}
+		}
+		return pgconn.CommandTag{}, pgx.ErrNoRows
+	}
 	return pgconn.CommandTag{}, nil
 }
 func (db *fakeDB) Begin(context.Context) (pgx.Tx, error) { return nil, nil }
+
+type fakeRow struct {
+	a   article
+	err error
+}
+
+func (r *fakeRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	if p, ok := dest[0].(*string); ok {
+		*p = r.a.id
+	}
+	if len(dest) > 1 {
+		if p, ok := dest[1].(*string); ok {
+			*p = r.a.slug
+		}
+	}
+	if len(dest) > 2 {
+		if p, ok := dest[2].(*string); ok {
+			*p = r.a.title
+		}
+	}
+	if len(dest) > 3 {
+		if p, ok := dest[3].(*string); ok {
+			*p = r.a.body
+		}
+	}
+	return nil
+}
 
 type fakeRows struct {
 	rows []article
@@ -89,5 +156,53 @@ func TestSearch(t *testing.T) {
 	}
 	if len(out) != 1 || out[0]["slug"].(string) != "slug" {
 		t.Fatalf("unexpected output: %v", out)
+	}
+}
+
+func TestCRUD(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := &fakeDB{}
+	cfg := apppkg.Config{Env: "test", TestBypassAuth: true}
+	a := apppkg.NewApp(cfg, db, nil, nil, nil)
+	a.R.POST("/kb", authpkg.Middleware(a), Create(a))
+	a.R.GET("/kb/:slug", authpkg.Middleware(a), Get(a))
+	a.R.PUT("/kb/:slug", authpkg.Middleware(a), Update(a))
+	a.R.DELETE("/kb/:slug", authpkg.Middleware(a), Delete(a))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/kb", strings.NewReader(`{"slug":"s1","title":"T1","body_md":"B1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/kb/s1", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 get, got %d", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPut, "/kb/s1", strings.NewReader(`{"slug":"s1","title":"T2","body_md":"B2"}`))
+	req.Header.Set("Content-Type", "application/json")
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 update, got %d", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodDelete, "/kb/s1", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 delete, got %d", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/kb/s1", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 get after delete, got %d", rr.Code)
 	}
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -786,6 +786,10 @@ func (a *App) mountAPI(rg *gin.RouterGroup) {
 	auth.GET("/teams", teamspkg.List(a.core()))
 	auth.GET("/slas", slaspkg.List(a.core()))
 	auth.GET("/kb", kbpkg.Search(a.core()))
+	auth.GET("/kb/:slug", kbpkg.Get(a.core()))
+	auth.POST("/kb", authpkg.RequireRole("agent", "manager"), kbpkg.Create(a.core()))
+	auth.PUT("/kb/:slug", authpkg.RequireRole("agent", "manager"), kbpkg.Update(a.core()))
+	auth.DELETE("/kb/:slug", authpkg.RequireRole("agent", "manager"), kbpkg.Delete(a.core()))
 
 	// Tickets
 	auth.GET("/tickets", ticketspkg.List(a.core()))

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1831,6 +1831,84 @@ paths:
       security:
         - bearerAuth: []
         - cookieAuth: []
+    post:
+      operationId: createKB
+      tags: [KnowledgeBase]
+      summary: Create knowledge base article
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/KBArticle' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/KBArticle' }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+
+  /kb/{slug}:
+    get:
+      operationId: getKB
+      tags: [KnowledgeBase]
+      summary: Get knowledge base article
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/KBArticle' }
+        '404': { description: Not Found }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+    put:
+      operationId: updateKB
+      tags: [KnowledgeBase]
+      summary: Update knowledge base article
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/KBArticle' }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/KBArticle' }
+        '404': { description: Not Found }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+    delete:
+      operationId: deleteKB
+      tags: [KnowledgeBase]
+      summary: Delete knowledge base article
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema: { type: string }
+      responses:
+        '204': { description: No Content }
+        '404': { description: Not Found }
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
 
   /webhooks/email-inbound:
     post:

--- a/web/requester/src/api.ts
+++ b/web/requester/src/api.ts
@@ -4,6 +4,7 @@ export type Ticket = components['schemas']['Ticket'];
 export type Comment = components['schemas']['Comment'];
 export type Attachment = components['schemas']['Attachment'];
 export type Requester = components['schemas']['Requester'];
+export type KBArticle = components['schemas']['KBArticle'];
 
 
 const API_BASE = import.meta.env.VITE_API_BASE || '/api';
@@ -87,6 +88,26 @@ export async function updateRequester(
     `/requesters/${id}`,
     {
       method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    },
+    token,
+  );
+}
+
+export async function listKBArticles(q?: string, token?: string): Promise<KBArticle[]> {
+  const qs = q ? `?q=${encodeURIComponent(q)}` : '';
+  return apiFetch<KBArticle[]>(`/kb${qs}`, {}, token);
+}
+
+export async function createKBArticle(
+  data: { slug: string; title: string; body_md: string },
+  token?: string,
+): Promise<KBArticle> {
+  return apiFetch<KBArticle>(
+    '/kb',
+    {
+      method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
     },

--- a/web/requester/src/components/KnowledgeBase.tsx
+++ b/web/requester/src/components/KnowledgeBase.tsx
@@ -1,24 +1,21 @@
-import { useState } from 'react';
-
-interface Article {
-  id: number;
-  title: string;
-  body: string;
-}
-
-const articles: Article[] = [
-  { id: 1, title: 'Reset Password', body: 'Visit the password portal and follow instructions.' },
-  { id: 2, title: 'VPN Setup', body: 'Download the VPN client and login with your company credentials.' },
-  { id: 3, title: 'Email Forwarding', body: 'In settings, add forwarding address and confirm.' },
-];
+import { useState, useEffect } from 'react';
+import { listKBArticles, type KBArticle } from '../api';
 
 export default function KnowledgeBase() {
-  const [selected, setSelected] = useState<Article | null>(null);
+  const [items, setItems] = useState<KBArticle[]>([]);
+  const [selected, setSelected] = useState<KBArticle | null>(null);
+
+  useEffect(() => {
+    listKBArticles()
+      .then(setItems)
+      .catch(() => setItems([]));
+  }, []);
+
   return (
     <div className="mx-auto max-w-2xl space-y-4 p-4">
       <h2 className="text-2xl font-semibold">Knowledge Base</h2>
       <ul className="space-y-2">
-        {articles.map(a => (
+        {items.map(a => (
           <li key={a.id}>
             <button
               className="text-left text-blue-600 hover:underline"
@@ -32,7 +29,7 @@ export default function KnowledgeBase() {
       {selected && (
         <article className="space-y-2 rounded border p-4">
           <h3 className="text-xl font-semibold">{selected.title}</h3>
-          <p>{selected.body}</p>
+          <p>{selected.body_md}</p>
         </article>
       )}
     </div>

--- a/web/requester/src/types/openapi.ts
+++ b/web/requester/src/types/openapi.ts
@@ -1134,6 +1134,16 @@ export interface paths {
   "/kb": {
     /** Search knowledge base articles */
     get: operations["searchKB"];
+    /** Create knowledge base article */
+    post: operations["createKB"];
+  };
+  "/kb/{slug}": {
+    /** Get knowledge base article */
+    get: operations["getKB"];
+    /** Update knowledge base article */
+    put: operations["updateKB"];
+    /** Delete knowledge base article */
+    delete: operations["deleteKB"];
   };
   "/webhooks/email-inbound": {
     /** Accept inbound email webhook */
@@ -2015,6 +2025,85 @@ export interface operations {
         content: {
           "application/json": components["schemas"]["KBArticle"][];
         };
+      };
+    };
+  };
+  /** Create knowledge base article */
+  createKB: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["KBArticle"];
+      };
+    };
+    responses: {
+      /** @description Created */
+      201: {
+        content: {
+          "application/json": components["schemas"]["KBArticle"];
+        };
+      };
+    };
+  };
+  /** Get knowledge base article */
+  getKB: {
+    parameters: {
+      path: {
+        slug: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["KBArticle"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: never;
+      };
+    };
+  };
+  /** Update knowledge base article */
+  updateKB: {
+    parameters: {
+      path: {
+        slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["KBArticle"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["KBArticle"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: never;
+      };
+    };
+  };
+  /** Delete knowledge base article */
+  deleteKB: {
+    parameters: {
+      path: {
+        slug: string;
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        content: never;
+      };
+      /** @description Not Found */
+      404: {
+        content: never;
       };
     };
   };


### PR DESCRIPTION
## Summary
- add kb article CRUD service and handlers
- expose /kb endpoints for search, read, write, update and delete
- fetch knowledge base articles on requester web UI

## Testing
- `go test -cover ./...`
- `npm --prefix web/requester test` *(fails: Missing script: "test")*
- `npx eslint src/api.ts src/components/KnowledgeBase.tsx && echo 'lint ok'`

------
https://chatgpt.com/codex/tasks/task_e_68c33cb073a08322915015539f6d18a0