### PR TITLE
email: enqueue acknowledgements and expose outbound logs

### DIFF
--- a/cmd/api/emails/outbound.go
+++ b/cmd/api/emails/outbound.go
@@ -1,0 +1,44 @@
+package emails
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	app "github.com/mark3748/helpdesk-go/cmd/api/app"
+)
+
+type Outbound struct {
+	ID       string    `json:"id"`
+	To       string    `json:"to"`
+	Subject  string    `json:"subject"`
+	Status   string    `json:"status"`
+	Retries  int       `json:"retries"`
+	TicketID *string   `json:"ticket_id,omitempty"`
+	Created  time.Time `json:"created_at"`
+}
+
+func ListOutbound(a *app.App) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rows, err := a.DB.Query(c.Request.Context(), `select id::text, to_addr, coalesce(subject,''), status, retries, ticket_id::text, created_at from email_outbound order by created_at desc limit 100`)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer rows.Close()
+		out := []Outbound{}
+		for rows.Next() {
+			var e Outbound
+			var tid *string
+			if err := rows.Scan(&e.ID, &e.To, &e.Subject, &e.Status, &e.Retries, &tid, &e.Created); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			if tid != nil && *tid != "" {
+				e.TicketID = tid
+			}
+			out = append(out, e)
+		}
+		c.JSON(http.StatusOK, out)
+	}
+}

--- a/cmd/api/emails/outbound_test.go
+++ b/cmd/api/emails/outbound_test.go
@@ -1,0 +1,84 @@
+package emails
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	apppkg "github.com/mark3748/helpdesk-go/cmd/api/app"
+	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
+)
+
+type fakeDB struct{}
+
+func (db *fakeDB) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	return &fakeRows{}, nil
+}
+func (db *fakeDB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	return fakeRow{}
+}
+func (db *fakeDB) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+func (db *fakeDB) Begin(ctx context.Context) (pgx.Tx, error) { return nil, nil }
+
+type fakeRows struct{ done bool }
+
+func (r *fakeRows) Close()                                       {}
+func (r *fakeRows) Err() error                                   { return nil }
+func (r *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeRows) RawValues() [][]byte                          { return nil }
+func (r *fakeRows) Values() ([]any, error)                       { return nil, nil }
+func (r *fakeRows) Conn() *pgx.Conn                              { return nil }
+func (r *fakeRows) Next() bool {
+	if r.done {
+		return false
+	}
+	r.done = true
+	return true
+}
+func (r *fakeRows) Scan(dest ...any) error {
+	*(dest[0].(*string)) = "1"
+	*(dest[1].(*string)) = "to@example.com"
+	*(dest[2].(*string)) = "subject"
+	*(dest[3].(*string)) = "sent"
+	*(dest[4].(*int)) = 1
+	if p, ok := dest[5].(**string); ok {
+		*p = nil
+	}
+	*(dest[6].(*time.Time)) = time.Unix(0, 0)
+	return nil
+}
+
+type fakeRow struct{}
+
+func (fakeRow) Scan(dest ...any) error { return pgx.ErrNoRows }
+
+func TestListOutbound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := &fakeDB{}
+	cfg := apppkg.Config{Env: "test", TestBypassAuth: true}
+	a := apppkg.NewApp(cfg, db, nil, nil, nil)
+	a.R.GET("/emails/outbound", authpkg.Middleware(a), ListOutbound(a))
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/emails/outbound", nil)
+	a.R.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var out []Outbound
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || out[0].Retries != 1 {
+		t.Fatalf("unexpected response %v", out)
+	}
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -51,6 +51,7 @@ import (
 	authpkg "github.com/mark3748/helpdesk-go/cmd/api/auth"
 	changespkg "github.com/mark3748/helpdesk-go/cmd/api/changes"
 	commentspkg "github.com/mark3748/helpdesk-go/cmd/api/comments"
+	emailspkg "github.com/mark3748/helpdesk-go/cmd/api/emails"
 	appevents "github.com/mark3748/helpdesk-go/cmd/api/events"
 	exportspkg "github.com/mark3748/helpdesk-go/cmd/api/exports"
 	handlers "github.com/mark3748/helpdesk-go/cmd/api/handlers"
@@ -830,6 +831,7 @@ func (a *App) mountAPI(rg *gin.RouterGroup) {
 	auth.GET("/tickets/:id/watchers", watcherspkg.List(a.core()))
 	auth.POST("/tickets/:id/watchers", watcherspkg.Add(a.core()))
 	auth.DELETE("/tickets/:id/watchers/:uid", watcherspkg.Remove(a.core()))
+	auth.GET("/emails/outbound", authpkg.RequireRole("admin"), emailspkg.ListOutbound(a.core()))
 	auth.GET("/metrics/sla", authpkg.RequireRole("agent"), metricspkg.SLA(a.core()))
 	auth.GET("/metrics/resolution", authpkg.RequireRole("agent"), metricspkg.Resolution(a.core()))
 	auth.GET("/metrics/tickets", authpkg.RequireRole("agent"), metricspkg.TicketVolume(a.core()))

--- a/cmd/worker/imap.go
+++ b/cmd/worker/imap.go
@@ -179,6 +179,12 @@ func processIMAPMessage(ctx context.Context, c Config, db app.DB, store app.Obje
 		}
 	}
 	if created {
+		if rdb != nil {
+			ej := EmailJob{To: from, Template: "ticket_created", Data: map[string]any{"Number": ticketID}}
+			b, _ := json.Marshal(ej)
+			nb, _ := json.Marshal(Job{Type: "send_email", Data: b})
+			_ = rdb.RPush(ctx, "jobs", nb).Err()
+		}
 		ws.PublishEvent(ctx, rdb, ws.Event{Type: "ticket_created", Data: map[string]interface{}{"id": ticketID}})
 	} else {
 		ws.PublishEvent(ctx, rdb, ws.Event{Type: "ticket_updated", Data: map[string]interface{}{"id": ticketID}})

--- a/cmd/worker/worker_test.go
+++ b/cmd/worker/worker_test.go
@@ -49,6 +49,9 @@ func TestSendEmail(t *testing.T) {
 	if db.lastSQL == "" || !strings.Contains(strings.ToLower(db.lastSQL), "email_outbound") {
 		t.Fatalf("expected insert into email_outbound, got %q", db.lastSQL)
 	}
+	if len(db.lastArgs) != 6 || db.lastArgs[4].(int) != 0 {
+		t.Fatalf("expected retries recorded, got %v", db.lastArgs)
+	}
 }
 
 func TestProcessQueueJob(t *testing.T) {


### PR DESCRIPTION
## Summary
- queue acknowledgement emails when tickets are created from inbound mail
- log outbound email retries and ticket references
- add API endpoint to list outbound email attempts

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68c3450bb510832291f76be913d16870